### PR TITLE
Move logic from main() method in to smaller methods

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ def start_prometheus():
 def get_extra(account="unknown", request_id="unknown"):
     return {"account": account, "request_id": request_id}
 
+producer = None
 
 def main():
 
@@ -32,42 +33,60 @@ def main():
         start_prometheus()
 
     consumer = consume.init_consumer()
+    global producer
     producer = produce.init_producer()
 
     while True:
         for data in consumer:
-            msg = data.value
-            msg["elapsed_time"] = time()
-            extra = get_extra(msg.get("account"), msg.get("request_id"))
-            logger.info("received request_id: %s", extra["request_id"])
-            producer.send(config.TRACKER_TOPIC, value=tracker.tracker_msg(extra, "received", "Received message"))
-            metrics.msg_count.inc()
-            facts = process.extraction(msg, extra)
-            if facts.get("error"):
-                metrics.extract_failure.inc()
-                producer.send(config.TRACKER_TOPIC, value=tracker.tracker_msg(extra, "failure", "Unable to extract facts"))
-                continue
-            logger.debug("extracted facts from message for %s", extra["request_id"])
-            inv_msg = {"operation": "add_host", "data": facts, "platform_metadata": msg}
-            inv_msg["data"]["account"] = msg.get("account")
             try:
-                inv_msg["data"]["elapsed_time"] = time() - msg["elapsed_time"]
-                logger.debug("Message traversed pup in %s seconds", inv_msg["data"]["elapsed_time"])
-                logger.debug("Message sent to Inventory: %s", extra["request_id"])
-                producer.send(config.INVENTORY_TOPIC, value=inv_msg)
-            except KafkaError:
-                logger.exception("Failed to produce message to inventory: %s", extra["request_id"])
-                metrics.msg_send_failure.inc()
-                continue
-            metrics.msg_processed.inc()
-            try:
-                producer.send(config.TRACKER_TOPIC, value=tracker.tracker_msg(extra, "success", "Sent to inventory"))
-            except KafkaError:
-                logger.exception("Failed to send payload tracker message for request %s", extra["request_id"])
-                metrics.msg_send_failure.inc()
-            metrics.msg_produced.inc()
+                handle_message(data.value)
+            except Exception:
+                logger.exception("An error occurred during message processing")
 
         producer.flush()
+
+
+def process_archive(msg, extra):
+    facts = process.extraction(msg, extra)
+    if facts.get("error"):
+        metrics.extract_failure.inc()
+        producer.send(config.TRACKER_TOPIC, value=tracker.tracker_msg(extra, "failure", "Unable to extract facts"))
+        return None
+    logger.debug("extracted facts from message for %s", extra["request_id"])
+    return facts
+
+
+def send_data_to_inventory(msg, facts, extra):
+    inv_msg = {"operation": "add_host", "data": facts, "platform_metadata": msg}
+    inv_msg["data"]["account"] = msg.get("account")
+    try:
+        inv_msg["data"]["elapsed_time"] = time() - msg["elapsed_time"]
+        logger.debug("Message traversed pup in %s seconds", inv_msg["data"]["elapsed_time"])
+        logger.debug("Message sent to Inventory: %s", extra["request_id"])
+        producer.send(config.INVENTORY_TOPIC, value=inv_msg)
+    except KafkaError:
+        logger.exception("Failed to produce message to inventory: %s", extra["request_id"])
+        metrics.msg_send_failure.inc()
+    metrics.msg_processed.inc()
+    try:
+        producer.send(config.TRACKER_TOPIC, value=tracker.tracker_msg(extra, "success", "Sent to inventory"))
+    except KafkaError:
+        logger.exception("Failed to send payload tracker message for request %s", extra["request_id"])
+        metrics.msg_send_failure.inc()
+    metrics.msg_produced.inc()
+
+
+def handle_message(msg):
+    msg["elapsed_time"] = time()
+    extra = get_extra(msg.get("account"), msg.get("request_id"))
+    logger.info("received request_id: %s", extra["request_id"])
+    producer.send(config.TRACKER_TOPIC, value=tracker.tracker_msg(extra, "received", "Received message"))
+    metrics.msg_count.inc()
+
+    facts = process_archive(msg, extra)
+
+    if facts:
+        send_data_to_inventory(msg, facts, extra)
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
This is a just a idea that I wanted to pass along.  This is not a PR that you must accept.  Its just food for thought...  :)

The idea here is to break the logic down into smaller chunks.  This should allow us to write tests for the individual chunks of logic.  This should allow us to build tests that send in valid data and invalid data into the individual methods and test the return values, exception, etc.

I think its also easier to follow the logic flow.  This allows me to follow the logic at a high level by using the names of the methods.  I can then step into the individual methods to dig into the lower level logic.

@SteveHNH let me know if you'd like to discuss, etc.