### PR TITLE
Provide NEVRAs in system profile

### DIFF
--- a/process.py
+++ b/process.py
@@ -81,7 +81,7 @@ def system_profile(hostname, cpu_info, virt_what, meminfo, ip_addr, dmidecode,
         profile['infrastructure_vendor'] = virt_what.generic
 
     if installed_rpms:
-        profile['installed_packages'] = sorted([str(p[0]) for p in installed_rpms.packages.values()])
+        profile['installed_packages'] = sorted([p[0].nevra for p in installed_rpms.packages.values()])
 
     if lsmod:
         profile['kernel_modules'] = list(lsmod.data.keys())


### PR DESCRIPTION
This is the first change necessary to remove archive re-processing from Vulnerabilities (https://github.com/RedHatInsights/vulnerability-engine/blob/master/listener/archive_parser.py).

And also removes this requirement from currently developed System Patch Management application
(https://github.com/RedHatInsights/patchman-engine)

Before this change, the installed_packages contained just a list of strings in `E:N-V-R` format. 