### PR TITLE
add "captured_date" to system profile

### DIFF
--- a/process.py
+++ b/process.py
@@ -87,6 +87,9 @@ def system_profile(hostname, cpu_info, virt_what, meminfo, ip_addr, dmidecode,
     if lsmod:
         profile['kernel_modules'] = list(lsmod.data.keys())
 
+    if date_utc:
+        profile['captured_date'] = date_utc.datetime.isoformat()
+
     if uptime and date_utc:
         boot_time = date_utc.datetime - uptime.uptime
         profile['last_boot_time'] = boot_time.isoformat()


### PR DESCRIPTION
This commit pulls in the "captured_date" to the system profile. This
date corresponds to when a system profile's data was saved by the
client system.

For example, if a client tarball was created on a Monday and uploaded
on a Tuesday, this date would be Monday.