### PR TITLE
add TZ to captured date

### DIFF
--- a/dev/full-stack.yml
+++ b/dev/full-stack.yml
@@ -94,3 +94,16 @@ services:
       - kafka
     ports:
       - "8081:8080"
+  inventory-rest:
+    image: inventory:mq # we expect this image to exist already
+    command: bash -c "make upgrade_db && make run_inv_web_service"
+    environment:
+      - INVENTORY_DB_HOST=db
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+    links:
+      - db
+    depends_on:
+      - db
+      - kafka
+    ports:
+      - "8082:8080"

--- a/process.py
+++ b/process.py
@@ -2,6 +2,8 @@ import requests
 import logging
 import json
 
+import datetime
+
 from tempfile import NamedTemporaryFile
 
 from utils import config, metrics
@@ -88,7 +90,10 @@ def system_profile(hostname, cpu_info, virt_what, meminfo, ip_addr, dmidecode,
         profile['kernel_modules'] = list(lsmod.data.keys())
 
     if date_utc:
-        profile['captured_date'] = date_utc.datetime.isoformat()
+        # re-inject UTC timezone into date_utc in order to obtain isoformat w/ TZ offset
+        utc_tz = datetime.timezone(datetime.timedelta(hours=0), name="UTC")
+        utcdate = date_utc.datetime.replace(tzinfo=utc_tz)
+        profile['captured_date'] = utcdate.isoformat()
 
     if uptime and date_utc:
         boot_time = date_utc.datetime - uptime.uptime


### PR DESCRIPTION
The date_utc supplied by insights-core is TZ-naive (see
https://git.io/JvVeG). This commit adds the TZ info back onto the
datetime object before pulling the isoformat().

old format of `captured_date`: `2020-01-10T15:50:47`
new format of `captured_date`: `2020-01-10T15:50:47+00:00`

NOTE:  this commit also adds `inventory-rest` to the
`full-stack.yml`, which listens on port 8082. This is useful for
pulling system profiles during local testing to confirm they are
landing correctly.