### PR TITLE
Add label for topic to produced messages

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -128,7 +128,7 @@ def delivery_report(err, msg=None, extra=None):
             err,
             extra["request_id"],
         )
-        metrics.msg_send_failure.inc()
+        metrics.msg_send_failure.labels(msg.topic()).inc()
     else:
         logger.info(
             "Message delivered to %s [%s] for request_id [%s]",
@@ -136,7 +136,7 @@ def delivery_report(err, msg=None, extra=None):
             msg.partition(),
             extra["request_id"],
         )
-        metrics.msg_produced.inc()
+        metrics.msg_produced.labels(msg.topic()).inc()
 
 
 @metrics.send_time.time()

--- a/src/puptoo/utils/metrics.py
+++ b/src/puptoo/utils/metrics.py
@@ -12,7 +12,7 @@ msg_count = Counter(
     "puptoo_messages_consumed_total", "Total messages consumed from the kafka topic"
 )
 extract_failure = Counter(
-    "puptoo_failed_extractions_total", "Total archives that failed to extract",
+    "puptoo_failed_extractions_total", "Total archives that failed to extract"
 )
 msg_processed = Counter(
     "puptoo_messages_processed_total", "Total messages successful process"

--- a/src/puptoo/utils/metrics.py
+++ b/src/puptoo/utils/metrics.py
@@ -12,14 +12,16 @@ msg_count = Counter(
     "puptoo_messages_consumed_total", "Total messages consumed from the kafka topic"
 )
 extract_failure = Counter(
-    "puptoo_failed_extractions_total", "Total archives that failed to extract"
+    "puptoo_failed_extractions_total", "Total archives that failed to extract",
 )
 msg_processed = Counter(
     "puptoo_messages_processed_total", "Total messages successful process"
 )
-msg_produced = Counter("puptoo_messages_produced_total", "Total messages produced")
+msg_produced = Counter(
+    "puptoo_messages_produced_total", "Total messages produced", ["topic"]
+)
 msg_send_failure = Counter(
-    "puptoo_messages_failed_to_send_total", "Total messages that failed to send"
+    "puptoo_messages_failed_to_send_total", "Total messages that failed to send", ["topic"]
 )
 
 send_time = Histogram(


### PR DESCRIPTION
We need this so that we can filter the payload-status topic out of the
messages

Signed-off-by: Stephen Adams <tsadams@gmail.com>