### PR TITLE
relocate the location of SAP system key

### DIFF
--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -123,9 +123,7 @@ def system_profile(
         profile["cores_per_socket"] = lscpu.info['Cores per socket']
 
     if sap:
-        profile["tags"].append({"namespace": "insights-client",
-                                "key": "sap_system",
-                                "value": "True"})
+        profile["sap_system"] = True
         profile["sap_local_instances"] = sap.local_instances
 
     if unit_files:


### PR DESCRIPTION
Tags should be user defined, so we're relocing this to the
system_profile

Signed-off-by: Stephen Adams <tsadams@gmail.com>