### PR TITLE
Fix tags parser of insights-client json

### DIFF
--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -268,7 +268,10 @@ def format_tags(tags):
     """
     tags_dict = {}
     for entry in tags:
-        namespace = entry.pop("namespace")
+        if entry.get("namespace"):
+            namespace = entry.pop("namespace")
+        else:
+            namespace = "insights-client"
         if tags_dict.get(namespace) is None:
             tags_dict[namespace] = {}
         tags_dict[namespace][entry["key"]] = []


### PR DESCRIPTION
The namespace value isn't always there in tags.json. This covers that
issue

Signed-off-by: Stephen Adams <tsadams@gmail.com>