### PR TITLE
Remove sap_version

### DIFF
--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -134,7 +134,6 @@ def system_profile(
         profile["sap_sids"] = sorted(list(sids))
         inst = sap.local_instances[0]
         profile["sap_instance_number"] = sap[inst].number
-        profile["sap_version"] = sap[inst].version
 
     if tuned:
         profile["tuned_profile"] = tuned.data['active']


### PR DESCRIPTION
There is a problem with the way we're grabbing this for hana instances
and it's blowing up in inventory.

Signed-off-by: Stephen Adams <tsadams@gmail.com>