### PR TITLE
Remove the 'at' symbol in some enabled_services

### DIFF
--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -334,7 +334,7 @@ def _enabled_services(unit_files):
     This method finds enabled services and strips the '.service' suffix
     """
     return [
-        service[:-8]
+        service[:-8].strip('@')
         for service in unit_files.services
         if unit_files.services[service] and ".service" in service
     ]


### PR DESCRIPTION
Some enabled_services end in '@' and some don't, this strips the '@'.
![image](https://user-images.githubusercontent.com/24516652/97899230-02918580-1d07-11eb-9d88-2963e8e5b781.png)
