### PR TITLE
Build with no-cache

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -15,7 +15,7 @@ DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
+docker --config="$DOCKER_CONF" build --no-cache -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
 
 if [ "${PUSH_TO_LATEST:=true}" == "true" ]; then


### PR DESCRIPTION
If we build with cache, we can miss updates to some of the underlying
python modules we need to install

Signed-off-by: Stephen Adams <tsadams@gmail.com>