### PR TITLE
feat: add ability to execute puptoo in shell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(
         "app-common-python==0.1.1"
     ],
     extras_require={"test": ["pytest>=5.4.1", "flake8>=3.7.9", "freezegun>=0.3.15"]},
-    entry_points={"console_scripts": ["puptoo = puptoo.app:main"]},
+    entry_points={"console_scripts": ["puptoo = puptoo.app:main",
+                                      "puptoo-run = puptoo.process:run_profile"]},
 )

--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -373,6 +373,29 @@ def _remove_bad_display_name(facts):
     return defined_facts
 
 
+def run_profile():
+
+    args = None
+
+    import argparse
+    import os
+    import sys
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("archive", nargs="?", help="Archive to analyze.")
+    args = p.parse_args()
+
+    root = args.archive
+    if root:
+        root = os.path.realpath(root)
+    try:
+        broker = run(system_profile, root=root)
+        result = broker[system_profile]
+        print(result)
+    except Exception as e:
+        print("something went wrong: %s" % e)
+        sys.exit(1)
+
+
 @metrics.SYSTEM_PROFILE.time()
 def get_system_profile(path=None):
     broker = run(system_profile, root=path)


### PR DESCRIPTION
This feature allows you to run puptoo's system_profile collection
against an archive without having to stand up an entire platform stack

Signed-off-by: Stephen Adams <tsadams@gmail.com>