### PR TITLE
feat: improve puptoo parser logging

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -10,6 +10,7 @@ from prometheus_client import Info, Summary, start_http_server
 from . import process
 from .mq import consume, msgs, produce
 from .utils import config, metrics, puptoo_logging
+from .utils.puptoo_logging import threadctx
 
 CONSUMER_WAIT_TIME = Summary(
     "puptoo_consumer_wait_time", "Time spent waiting on consumer iteration"
@@ -26,6 +27,8 @@ def start_prometheus():
 
 
 def get_extra(account="unknown", request_id="unknown"):
+    threadctx.request_id = request_id
+    threadctx.account = account
     return {"account": account, "request_id": request_id}
 
 

--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -30,7 +30,7 @@ from insights.parsers.yum_repos_d import YumReposD
 from insights.specs import Specs
 from insights.util.canonical_facts import get_canonical_facts
 
-from .utils import config, metrics
+from .utils import config, metrics, puptoo_logging
 
 logger = logging.getLogger(config.APP_NAME)
 
@@ -41,6 +41,11 @@ dr.log.setLevel(config.FACT_EXTRACT_LOGLEVEL)
 def get_archive(url):
     archive = requests.get(url)
     return archive.content
+
+
+def catch_error(parser, error):
+    log_msg = "System Profile failed due to %s encountering an error: %s"
+    logger.error(log_msg, parser, error)
 
 
 @rule(
@@ -109,170 +114,269 @@ def system_profile(
     ignores any key with None as the value.
     """
     profile = {"tags": {}}
+
     if uname:
-        profile["arch"] = uname.arch
+        try:
+            profile["arch"] = uname.arch
+        except Exception as e:
+            catch_error("uname", e)
+            raise
 
     if dmidecode:
         try:
             profile["bios_release_date"] = dmidecode.bios.get("release_date")
             profile["bios_vendor"] = dmidecode.bios.get("vendor")
             profile["bios_version"] = dmidecode.bios.get("version")
-        except AttributeError:
-            pass
+        except Exception as e:
+            catch_error("dmidecode", e)
+            raise
 
     if cpu_info:
-        profile["cpu_flags"] = cpu_info.flags
-        profile["number_of_cpus"] = cpu_info.cpu_count
-        profile["number_of_sockets"] = cpu_info.socket_count
+        try:
+            profile["cpu_flags"] = cpu_info.flags
+            profile["number_of_cpus"] = cpu_info.cpu_count
+            profile["number_of_sockets"] = cpu_info.socket_count
+        except Exception as e:
+            catch_error("cpuinfo", e)
+            raise
 
     if lscpu:
-        profile["cores_per_socket"] = lscpu.info['Cores per socket']
+        try:
+            profile["cores_per_socket"] = lscpu.info['Cores per socket']
+        except Exception as e:
+            catch_error("lscpu", e)
+            raise
 
     if sap:
-        profile["sap_system"] = True
-        sids = {sap.sid(instance) for instance in sap.local_instances}
-        profile["sap_sids"] = sorted(list(sids))
-        if sap.local_instances:
-            inst = sap.local_instances[0]
-            if sap[inst].number not in ["98", "99"]:
-                profile["sap_instance_number"] = sap[inst].number
+        try:
+            profile["sap_system"] = True
+            sids = {sap.sid(instance) for instance in sap.local_instances}
+            profile["sap_sids"] = sorted(list(sids))
+            if sap.local_instances:
+                inst = sap.local_instances[0]
+                if sap[inst].number not in ["98", "99"]:
+                    profile["sap_instance_number"] = sap[inst].number
+        except Exception as e:
+            catch_error("sap", e)
+            raise
 
     if tuned:
-        profile["tuned_profile"] = tuned.data['active']
+        try:
+            profile["tuned_profile"] = tuned.data['active']
+        except Exception as e:
+            catch_error("tuned", e)
+            raise
 
     if sestatus:
-        profile["selinux_current_mode"] = sestatus.data['current_mode'].lower()
-        profile["selinux_config_file"] = sestatus.data['mode_from_config_file']
+        try:
+            profile["selinux_current_mode"] = sestatus.data['current_mode'].lower()
+            profile["selinux_config_file"] = sestatus.data['mode_from_config_file']
+        except Exception as e:
+            catch_error("sestatus", e)
+            raise
 
     if unit_files:
-        profile["enabled_services"] = _enabled_services(unit_files)
-        profile["installed_services"] = _installed_services(unit_files)
+        try:
+            profile["enabled_services"] = _enabled_services(unit_files)
+            profile["installed_services"] = _installed_services(unit_files)
+        except Exception as e:
+            catch_error("unit_files", e)
+            raise
 
     if virt_what:
-        profile["infrastructure_type"] = _get_virt_phys_fact(virt_what)
-        profile["infrastructure_vendor"] = virt_what.generic
+        try:
+            profile["infrastructure_type"] = _get_virt_phys_fact(virt_what)
+            profile["infrastructure_vendor"] = virt_what.generic
+        except Exception as e:
+            catch_error("virt_what", e)
+            raise
 
     if installed_rpms:
-        profile["installed_packages"] = sorted(
-            [installed_rpms.get_max(p).nevra for p in installed_rpms.packages]
-        )
+        try:
+            profile["installed_packages"] = sorted(
+                [installed_rpms.get_max(p).nevra for p in installed_rpms.packages]
+            )
+        except Exception as e:
+            catch_error("installed_packages", e)
+            raise
 
     if lsmod:
-        profile["kernel_modules"] = list(lsmod.data.keys())
+        try:
+            profile["kernel_modules"] = list(lsmod.data.keys())
+        except Exception as e:
+            catch_error("lsmod", e)
+            raise
 
     if date_utc:
-        # re-inject UTC timezone into date_utc in order to obtain isoformat w/ TZ offset
-        utc_tz = datetime.timezone(datetime.timedelta(hours=0), name="UTC")
-        utcdate = date_utc.datetime.replace(tzinfo=utc_tz)
-        profile["captured_date"] = utcdate.isoformat()
+        try:
+            # re-inject UTC timezone into date_utc in order to obtain isoformat w/ TZ offset
+            utc_tz = datetime.timezone(datetime.timedelta(hours=0), name="UTC")
+            utcdate = date_utc.datetime.replace(tzinfo=utc_tz)
+            profile["captured_date"] = utcdate.isoformat()
+        except Exception as e:
+            catch_error("date_utc", e)
+            raise
 
     if uptime and date_utc:
-        boot_time = date_utc.datetime - uptime.uptime
-        profile["last_boot_time"] = boot_time.isoformat()
+        try:
+            boot_time = date_utc.datetime - uptime.uptime
+            profile["last_boot_time"] = boot_time.isoformat()
+        except Exception as e:
+            catch_error("uptime", e)
+            raise
 
     if ip_addr:
-        network_interfaces = []
-        for iface in ip_addr:
-            interface = {
-                "ipv4_addresses": iface.addrs(version=4),
-                "ipv6_addresses": iface.addrs(version=6),
-                "mac_address": _safe_fetch_interface_field(iface, "mac"),
-                "mtu": _safe_fetch_interface_field(iface, "mtu"),
-                "name": _safe_fetch_interface_field(iface, "name"),
-                "state": _safe_fetch_interface_field(iface, "state"),
-                "type": _safe_fetch_interface_field(iface, "type"),
-            }
-            network_interfaces.append(_remove_empties(interface))
+        try:
+            network_interfaces = []
+            for iface in ip_addr:
+                interface = {
+                    "ipv4_addresses": iface.addrs(version=4),
+                    "ipv6_addresses": iface.addrs(version=6),
+                    "mac_address": _safe_fetch_interface_field(iface, "mac"),
+                    "mtu": _safe_fetch_interface_field(iface, "mtu"),
+                    "name": _safe_fetch_interface_field(iface, "name"),
+                    "state": _safe_fetch_interface_field(iface, "state"),
+                    "type": _safe_fetch_interface_field(iface, "type"),
+                }
+                network_interfaces.append(_remove_empties(interface))
 
-        profile["network_interfaces"] = network_interfaces
+            profile["network_interfaces"] = network_interfaces
+        except Exception as e:
+            catch_error("ip_addr", e)
+            raise
 
     if uname:
-        profile["os_kernel_version"] = uname.version
-        profile["os_kernel_release"] = uname.release
+        try:
+            profile["os_kernel_version"] = uname.version
+            profile["os_kernel_release"] = uname.release
+        except Exception as e:
+            catch_error("uname", e)
+            raise
 
     if redhat_release:
         try:
             profile["os_release"] = redhat_release.rhel
-        except AttributeError:
-            pass
+        except Exception as e:
+            catch_error("redhat_release", e)
+            raise
 
     if ps_auxcww:
-        profile["running_processes"] = list(ps_auxcww.running)
+        try:
+            profile["running_processes"] = list(ps_auxcww.running)
+        except Exception as e:
+            catch_error("ps_auxcww", e)
+            raise
 
     if meminfo:
-        profile["system_memory_bytes"] = meminfo.total
+        try:
+            profile["system_memory_bytes"] = meminfo.total
+        except Exception as e:
+            catch_error("meminfo", e)
+            raise
 
     if yum_repos_d:
-        repos = []
-        for yum_repo_file in yum_repos_d:
-            for yum_repo_definition in yum_repo_file:
-                baseurl = yum_repo_file[yum_repo_definition].get("baseurl", [])
-                repo = {
-                    "id": yum_repo_definition,
-                    "name": yum_repo_file[yum_repo_definition].get("name"),
-                    "base_url": baseurl[0] if len(baseurl) > 0 else None,
-                    "enabled": _to_bool(
-                        yum_repo_file[yum_repo_definition].get("enabled")
-                    ),
-                    "gpgcheck": _to_bool(
-                        yum_repo_file[yum_repo_definition].get("gpgcheck")
-                    ),
-                }
-                repos.append(_remove_empties(repo))
-        profile["yum_repos"] = repos
+        try:
+            repos = []
+            for yum_repo_file in yum_repos_d:
+                for yum_repo_definition in yum_repo_file:
+                    baseurl = yum_repo_file[yum_repo_definition].get("baseurl", [])
+                    repo = {
+                        "id": yum_repo_definition,
+                        "name": yum_repo_file[yum_repo_definition].get("name"),
+                        "base_url": baseurl[0] if len(baseurl) > 0 else None,
+                        "enabled": _to_bool(
+                            yum_repo_file[yum_repo_definition].get("enabled")
+                        ),
+                        "gpgcheck": _to_bool(
+                            yum_repo_file[yum_repo_definition].get("gpgcheck")
+                        ),
+                    }
+                    repos.append(_remove_empties(repo))
+            profile["yum_repos"] = repos
+        except Exception as e:
+            catch_error("yum_repos_d", e)
+            raise
 
     if dnf_modules:
-        modules = []
-        for module in dnf_modules:
-            for module_name in module.sections():
-                modules.append(
-                    {"name": module_name, "stream": module.get(module_name, "stream")}
-                )
-        profile["dnf_modules"] = modules
+        try:
+            modules = []
+            for module in dnf_modules:
+                for module_name in module.sections():
+                    modules.append(
+                        {"name": module_name, "stream": module.get(module_name, "stream")}
+                    )
+            profile["dnf_modules"] = modules
+        except Exception as e:
+            catch_error("dnf_modules", e)
+            raise
 
     if cloud_provider:
-        profile["cloud_provider"] = cloud_provider.cloud_provider
+        try:
+            profile["cloud_provider"] = cloud_provider.cloud_provider
+        except Exception as e:
+            catch_error("cloud_provider", e)
+            raise
 
     if display_name:
-        profile["display_name"] = display_name.content[0]
+        try:
+            profile["display_name"] = display_name.content[0]
+        except Exception as e:
+            catch_error("display_name", e)
+            raise
 
     if version_info:
-        version_info_json = json.loads(version_info.content[0])
-        profile["insights_client_version"] = version_info_json["client_version"]
-        profile["insights_egg_version"] = version_info_json["core_version"]
+        try:
+            version_info_json = json.loads(version_info.content[0])
+            profile["insights_client_version"] = version_info_json["client_version"]
+            profile["insights_egg_version"] = version_info_json["core_version"]
+        except Exception as e:
+            catch_error("version_info", e)
+            raise
 
     if branch_info:
-        branch_info_json = json.loads(branch_info.content.decode("utf-8"))
-        if branch_info_json["remote_branch"] != -1:
-            profile["satellite_managed"] = True
-            profile["satellite_id"] = branch_info_json["remote_leaf"]
-        else:
-            profile["satellite_managed"] = False
-        if branch_info_json.get("labels"):
-            if type(branch_info_json["labels"]) == list:
-                new_tags = format_tags(branch_info_json["labels"])
-                profile["tags"].update(new_tags)
+        try:
+            branch_info_json = json.loads(branch_info.content.decode("utf-8"))
+            if branch_info_json["remote_branch"] != -1:
+                profile["satellite_managed"] = True
+                profile["satellite_id"] = branch_info_json["remote_leaf"]
             else:
-                profile["tags"].update(branch_info_json["labels"])
+                profile["satellite_managed"] = False
+            if branch_info_json.get("labels"):
+                if type(branch_info_json["labels"]) == list:
+                    new_tags = format_tags(branch_info_json["labels"])
+                    profile["tags"].update(new_tags)
+                else:
+                    profile["tags"].update(branch_info_json["labels"])
+        except Exception as e:
+            catch_error("branch_info", e)
+            raise
 
     if product_ids:
-        profile["installed_products"] = [
-            {"id": product_id} for product_id in product_ids.ids
-        ]
+        try:
+            profile["installed_products"] = [
+                {"id": product_id} for product_id in product_ids.ids
+            ]
+        except Exception as e:
+            catch_error("product_ids", e)
+            raise
 
     if tags:
-        tags_json = json.loads(tags.content.decode("utf-8"))
-        if type(tags_json) == list:
-            new_tags = format_tags(tags_json)
-            profile["tags"].update(new_tags)
-        else:
-            # Need to turn the values into a list
-            for entry in tags_json.keys():
-                for k, v in tags_json[entry].items():
-                    if type(tags_json[entry][k]) != list:
-                        tags_json[entry][k] = []
-                        tags_json[entry][k].append(v)
-            profile["tags"].update(tags_json)
+        try:
+            tags_json = json.loads(tags.content.decode("utf-8"))
+            if type(tags_json) == list:
+                new_tags = format_tags(tags_json)
+                profile["tags"].update(new_tags)
+            else:
+                # Need to turn the values into a list
+                for entry in tags_json.keys():
+                    for k, v in tags_json[entry].items():
+                        if type(tags_json[entry][k]) != list:
+                            tags_json[entry][k] = []
+                            tags_json[entry][k].append(v)
+                profile["tags"].update(tags_json)
+        except Exception as e:
+            catch_error("tags", e)
+            raise
 
     metadata_response = make_metadata()
     profile_sans_none = _remove_empties(profile)
@@ -380,6 +484,8 @@ def run_profile():
     import argparse
     import os
     import sys
+
+    puptoo_logging.initialize_logging()
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("archive", nargs="?", help="Archive to analyze.")
     args = p.parse_args()
@@ -392,7 +498,7 @@ def run_profile():
         result = broker[system_profile]
         print(result)
     except Exception as e:
-        print("something went wrong: %s" % e)
+        print("System_profile failure: %s" % e)
         sys.exit(1)
 
 


### PR DESCRIPTION
When a parser fails in system_profile we need to be able to easily
track down which one caused the problem. This new system will log each
parser when it fails and cause the payload to be rejected. We will be
able to search these failures with the request_id in kibana which will
help speed up troubleshooting time.

Signed-off-by: Stephen Adams <tsadams@gmail.com>