### PR TITLE
fix: ensure pr_check fails if system_profile breaks

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,6 +14,9 @@ for file in dev/test-archives/*; do
      filename="$(basename "$file").tar.gz"
      tar -zcf $filename "$file"
      puptoo-run $filename
+     if [ $? != 0 ]; then
+        exit 1
+     fi
      rm $filename
 done
 


### PR DESCRIPTION
If the system_profile cannot be gathered during the test run, we want to
ensure that the PR check fails. This should give us a way to verify that
the specs being run are all accurate

Signed-off-by: Stephen Adams <tsadams@gmail.com>