### PR TITLE
fix(logging): add context filter to cloudwatch logs

### DIFF
--- a/src/puptoo/utils/puptoo_logging.py
+++ b/src/puptoo/utils/puptoo_logging.py
@@ -27,6 +27,7 @@ def config_cloudwatch(logger):
         create_log_group=False,
     )
     cw_handler.setFormatter(LogstashFormatterV1())
+    cw_handler.addFilter(ContextualFilter())
     logger.addHandler(cw_handler)
 
 


### PR DESCRIPTION
The filter for adding request_id and account to the logs was missing
from cloudwatch. Adding it so that we can search those fields in kibana

Signed-off-by: Stephen Adams <tsadams@gmail.com>