### PR TITLE
fix: tuned bug within system_profile

### DIFF
--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -162,7 +162,8 @@ def system_profile(
 
     if tuned:
         try:
-            profile["tuned_profile"] = tuned.data['active']
+            if 'active' in tuned.data:
+                profile["tuned_profile"] = tuned.data['active']
         except Exception as e:
             catch_error("tuned", e)
             raise


### PR DESCRIPTION
The tuned parser was failing if tuned was not active on the system.
This should correct that behavior

BZ1893818

Signed-off-by: Stephen Adams <tsadams@gmail.com>