### PR TITLE
fix: make lscpu parser more forgivable

### DIFF
--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -143,7 +143,7 @@ def system_profile(
 
     if lscpu:
         try:
-            profile["cores_per_socket"] = lscpu.info['Cores per socket']
+            profile["cores_per_socket"] = lscpu.info.get('Cores per socket')
         except Exception as e:
             catch_error("lscpu", e)
             raise


### PR DESCRIPTION
The lscpu parser can fail on archives if `Cores per socket` is not a
key. Use `.get` to make it safer to run

Signed-off-by: Stephen Adams <tsadams@gmail.com>