### PR TITLE
Revert sap instances 98/99 workaround

### DIFF
--- a/src/puptoo/process.py
+++ b/src/puptoo/process.py
@@ -155,8 +155,7 @@ def system_profile(
             profile["sap_sids"] = sorted(list(sids))
             if sap.local_instances:
                 inst = sap.local_instances[0]
-                if sap[inst].number not in ["98", "99"]:
-                    profile["sap_instance_number"] = sap[inst].number
+                profile["sap_instance_number"] = sap[inst].number
         except Exception as e:
             catch_error("sap", e)
             raise


### PR DESCRIPTION
This workaround was added in response to:

https://issues.redhat.com/browse/HBISPSC-37

Once the inventory and schema PRs are merged, we can revert this change:
https://github.com/RedHatInsights/inventory-schemas/pull/39
https://github.com/RedHatInsights/insights-host-inventory/pull/773

*Only* merge this PR once the above two PRs are merged so as not to cause any errors.