### PR TITLE
Fix reading CLOWDER_ENABLED boolean env var so 'False' works as expected

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -93,4 +93,4 @@ parameters:
   required: true
 - description: Is clowder enabled
   name: CLOWDER_ENABLED
-  value: "true"
+  value: "True"

--- a/src/puptoo/utils/config.py
+++ b/src/puptoo/utils/config.py
@@ -26,7 +26,7 @@ def get_namespace():
 
 
 # Shim layer for dual support of using Clowder and Legacy Mode
-CLOWDER_ENABLED = os.environ.get("CLOWDER_ENABLED", False)
+CLOWDER_ENABLED = True if os.getenv("CLOWDER_ENABLED", default="False").lower() in ["true", "t", "yes", "y"] else False
 if CLOWDER_ENABLED:
     logger.info("Using Clowder Operator...")
     from app_common_python import LoadedConfig, KafkaTopics


### PR DESCRIPTION
The PR #77 that added dual support for clowder and legacy doesn't allow setting the env variable to anything that will result in False boolean value - any text string at all results in the variable in config.py being set to true.  This fixes that problem so only case-insensitive values of "true", "t", "yes", or "y" will result in the CLOWDER_ENABLED variable being set to True.  Any other value for the CLOWDER_ENABLED env var (or no value at all) will result in the variable being set to False.  Previously, the only way to get the variable set to false was to make sure no CLOWDER_ENABLED env var was defined, or it was set to an empty string.

Note this might be nice to apply to the DISABLE_PROMETHEUS variable as well as it will make the test for the env var value case insensitive and it adds "t", "yes", and "y" as values that result in True boolean value.

Finally, this PR also "fixes" what I think is a typo from yesterday's PR #110 that set the env var value to "true", which in the case-sensitive code used to set the DISABLE_PROMETHEUS variable in config.py, would have resulted in a boolean value of False.