### PR TITLE
Separate archive processing and system profile parsing, reformat according to flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ freezegun = "^0.3.15"
 
 [tool.poetry.scripts]
 puptoo = 'src.puptoo.app:main'
-puptoo-run = 'src.puptoo.process:run_profile'
+puptoo-run = 'src.puptoo.process.profile:run_profile'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -7,7 +7,7 @@ from time import time
 from confluent_kafka import KafkaError
 from prometheus_client import Info, Summary, start_http_server
 
-from . import process
+from .process import extract
 from .mq import consume, msgs, produce
 from .utils import config, metrics, puptoo_logging
 from .utils.puptoo_logging import threadctx
@@ -95,7 +95,7 @@ def main():
 
 
 def process_archive(msg, extra):
-    facts = process.extraction(msg, extra)
+    facts = extract(msg, extra)
     if facts.get("error"):
         metrics.extract_failure.inc()
         send_message(

--- a/src/puptoo/process/__init__.py
+++ b/src/puptoo/process/__init__.py
@@ -1,0 +1,55 @@
+from contextlib import contextmanager
+import logging
+from tempfile import NamedTemporaryFile
+
+import requests
+from insights import extract as extract_archive
+from insights.util.canonical_facts import get_canonical_facts
+
+from .profile import get_system_profile, postprocess
+from ..utils import config, metrics
+logger = logging.getLogger(config.APP_NAME)
+
+
+@metrics.GET_FILE.time()
+def get_archive(url):
+    archive = requests.get(url)
+    return archive.content
+
+
+@contextmanager
+def unpacked_archive(msg, remove=True):
+    """
+    Simple ContextManager which is used to for automatically downloading + unpacking
+    insights archive, and performing cleanup when needed.
+    """
+    metrics.extraction_count.inc()
+    try:
+        with NamedTemporaryFile(delete=remove) as tf:
+            tf.write(get_archive(msg["url"]))
+            tf.flush()
+            with extract_archive(tf.name) as ex:
+                yield ex
+    finally:
+        metrics.msg_processed.inc()
+        metrics.extract_success.inc()
+
+
+@metrics.EXTRACT.time()
+def extract(msg, extra, remove=True):
+    """
+    Perform the extraction of canonical system facts and system profile.
+    """
+    facts = {"system_profile": {}}
+    with unpacked_archive(msg, remove) as unpacked:
+        try:
+            facts = get_canonical_facts(unpacked.tmp_dir)
+            facts['system_profile'] = get_system_profile(unpacked.tmp_dir)
+        except Exception as e:
+            logger.exception("Failed to extract facts: %s", str(e), extra=extra)
+            facts["error"] = str(e)
+        finally:
+            facts = postprocess(facts)
+            metrics.msg_processed.inc()
+            metrics.extract_success.inc()
+            return facts

--- a/src/puptoo/utils/config.py
+++ b/src/puptoo/utils/config.py
@@ -30,7 +30,7 @@ CLOWDER_ENABLED = True if os.getenv("CLOWDER_ENABLED", default="False").lower() 
 if CLOWDER_ENABLED:
     logger.info("Using Clowder Operator...")
     from app_common_python import LoadedConfig, KafkaTopics
-    BOOTSTRAP_SERVERS = os.getenv("BOOTSTRAP_SERVERS", LoadedConfig.kafka.brokers[0].hostname+":"+str(LoadedConfig.kafka.brokers[0].port)).split(",")
+    BOOTSTRAP_SERVERS = os.getenv("BOOTSTRAP_SERVERS", LoadedConfig.kafka.brokers[0].hostname + ":" + str(LoadedConfig.kafka.brokers[0].port)).split(",")
     ADVISOR_TOPIC = os.getenv("CONSUME_TOPIC", KafkaTopics["platform.upload.advisor"].name)
     COMPLIANCE_TOPIC = os.getenv("COMPLIANCE_TOPIC", KafkaTopics["platform.upload.compliance"].name)
     INVENTORY_TOPIC = os.getenv("INVENTORY_TOPIC") or KafkaTopics["platform.inventory.host-ingress-p1"].name


### PR DESCRIPTION
- The process module contained logic for both the archive extraction and logic working with the system profile. Separated this into a submodule, where `profile.py` logic does not deal with archives, but instead only deals with invocation of insights-core rule, and subsequent data cleanup.
- The `process` module now only deals with working with archives, added new ContextManager, which does both downloading and extraction of the archives.
- Flake8 returned some errors, reformated some small amount of code.