### PR TITLE
fix(compliance): Fix owner_id bug for compliance

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -189,7 +189,7 @@ def handle_message(msg):
     if facts:
         facts["stale_timestamp"] = get_staletime()
         facts["reporter"] = "puptoo"
-        if owner_id:
+        if owner_id and facts.get("system_profile"):
             facts["system_profile"]["owner_id"] = owner_id
         send_message(
             config.INVENTORY_TOPIC, msgs.inv_message("add_host", facts, msg), extra


### PR DESCRIPTION
Compliance payloads do not have system_profile so we have to make sure
we don't try to call it before sending to inventory. This will allow us
to only add owner ID to payloads with both an owner_id and a
system_profile

Signed-off-by: Stephen Adams <tsadams@gmail.com>