### PR TITLE
feat(system_profile): Add ROS check

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -189,8 +189,11 @@ def handle_message(msg):
     if facts:
         facts["stale_timestamp"] = get_staletime()
         facts["reporter"] = "puptoo"
-        if owner_id and facts.get("system_profile"):
-            facts["system_profile"]["owner_id"] = owner_id
+        if facts.get("system_profile"):
+            if owner_id:
+                facts["system_profile"]["owner_id"] = owner_id
+            if facts["system_profile"].get("is_ros"):
+                msg["is_ros"] = "true"
         send_message(
             config.INVENTORY_TOPIC, msgs.inv_message("add_host", facts, msg), extra
         )

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -69,6 +69,7 @@ def catch_error(parser, error):
         InstalledProductIDs,
         Specs.branch_info,
         Specs.tags,
+        Specs.pmlog_summary,
     ]
 )
 def system_profile(
@@ -99,6 +100,7 @@ def system_profile(
     product_ids,
     branch_info,
     tags,
+    pmlog_summary,
 ):
     """
     This method applies parsers to a host and returns a system profile that can
@@ -395,6 +397,9 @@ def system_profile(
         except Exception as e:
             catch_error("tags", e)
             raise
+
+    if pmlog_summary:
+        profile["is_ros"] = True
 
     metadata_response = make_metadata()
     profile_sans_none = _remove_empties(profile)


### PR DESCRIPTION
Depends on: https://github.com/RedHatInsights/insights-core/pull/2950

If the archive contains ROS data, we want to indicate that in the
platform_metadata. This is so that the ROS receiver can filter on
messages that only pertain to them, rather than fully processing all
insights archives.

RHCLOUD-12226

Signed-off-by: Stephen Adams <tsadams@gmail.com>