### PR TITLE
task: adjust staletime to 29 hours

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -34,7 +34,7 @@ def get_extra(account="unknown", request_id="unknown"):
 
 
 def get_staletime():
-    the_time = datetime.now() + timedelta(hours=26)
+    the_time = datetime.now() + timedelta(hours=29)
     return the_time.astimezone().isoformat()
 
 


### PR DESCRIPTION
Since there is 4 hour drift on insights-client uploads. It's possible to
miss the window and have a system appear as stale. Increasing our
staletime to 29 hours should help avoid this.

RHCLOUD-12827

Signed-off-by: Stephen Adams <tsadams@gmail.com>