### PR TITLE
Also send null rhsm fact

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -297,6 +297,8 @@ def system_profile(
             catch_error("redhat_release", e)
             raise
 
+    # By default, always provide None value
+    profile["rhsm"] = None
     if rhsm_releasever:
         try:
             # We can add pre-parsed minor + major values, but the schema specifies just version


### PR DESCRIPTION
Inventory does not delete missing system facts, we need to send a `null` rhsm version if it is not available.