### PR TITLE
[feat] add check of unextracted size

### DIFF
--- a/src/puptoo/process/__init__.py
+++ b/src/puptoo/process/__init__.py
@@ -23,9 +23,12 @@ def validate_size(path):
     reject payloads where the extracted size exceeds the configured max
     """
     total_size = sum(p.stat().st_size for p in Path(path).rglob('*'))
-    if total_size >= config.MAX_EXTRACTED_SIZE:
-        err_msg = f"Archive exceeds unextracted file limit of {config.MAX_EXTRACTED_SIZE}"
-        raise Exception(err_msg)
+    metrics.msg_extraction_size.observe(total_size)
+    if total_size >= int(config.MAX_EXTRACTED_SIZE):
+        metrics.msg_size_exceeded.inc()
+        # TODO: actively reject payloads that exceed our configured max size
+        # err_msg = f"Archive exceeds unextracted file limit of {config.MAX_EXTRACTED_SIZE}"
+        # raise Exception(err_msg)
 
 
 @contextmanager

--- a/src/puptoo/process/__init__.py
+++ b/src/puptoo/process/__init__.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import logging
 from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 import requests
 from insights import extract as extract_archive
@@ -15,6 +16,16 @@ logger = logging.getLogger(config.APP_NAME)
 def get_archive(url):
     archive = requests.get(url)
     return archive.content
+
+
+def validate_size(path):
+    """
+    reject payloads where the extracted size exceeds the configured max
+    """
+    total_size = sum(p.stat().st_size for p in Path(path).rglob('*'))
+    if total_size >= config.MAX_EXTRACTED_SIZE:
+        err_msg = f"Archive exceeds unextracted file limit of {config.MAX_EXTRACTED_SIZE}"
+        raise Exception(err_msg)
 
 
 @contextmanager
@@ -43,6 +54,7 @@ def extract(msg, extra, remove=True):
     facts = {"system_profile": {}}
     with unpacked_archive(msg, remove) as unpacked:
         try:
+            validate_size(unpacked.tmp_dir)
             facts = get_canonical_facts(unpacked.tmp_dir)
             facts['system_profile'] = get_system_profile(unpacked.tmp_dir)
         except Exception as e:

--- a/src/puptoo/utils/config.py
+++ b/src/puptoo/utils/config.py
@@ -53,6 +53,7 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 GROUP_ID = os.getenv("GROUP_ID", APP_NAME)
 FACT_EXTRACT_LOGLEVEL = os.getenv("FACT_EXTRACT_LOGLEVEL", "ERROR")
 DISABLE_PROMETHEUS = True if os.getenv("DISABLE_PROMETHEUS") == "True" else False
+MAX_EXTRACTED_SIZE = os.getenv("MAX_EXTRACTED_SIZE", 1000000000)  # 1GB Default
 NAMESPACE = get_namespace()
 HOSTNAME = os.environ.get("HOSTNAME")
 BUILD_COMMIT = os.getenv("OPENSHIFT_BUILD_COMMIT", "not_in_openshift")

--- a/src/puptoo/utils/metrics.py
+++ b/src/puptoo/utils/metrics.py
@@ -30,9 +30,17 @@ msg_produced = Counter(
     "puptoo_messages_produced_total", "Total messages produced", ["topic"]
 )
 msg_send_failure = Counter(
-    "puptoo_messages_produced_failure_total", "Total messages that failed to send", ["topic"]
+    "puptoo_messages_produced_failure_total",
+    "Total messages that failed to send",
+    ["topic"],
+)
+msg_size_exceeded = Counter(
+    "puptoo_max_extracted_size_exceeded_total",
+    "Total archives with exceeded extracted size",
 )
 
 send_time = Histogram(
     "puptoo_message_send_time_seconds", "Total time spent sending a message"
 )
+
+msg_extraction_size = Histogram("puptoo_extraction_sizes", "Extracted archive sizes")


### PR DESCRIPTION
If we get archives with more than 1GB of unextracted data, we tend to
blow up in the engine. We should not be getting that much data at a
time. This adds a check of that unextracted file size and rejects any
archives that are too large.

Signed-off-by: Stephen Adams <tsadams@gmail.com>