### PR TITLE
DO NOT MERGE: [profile] ensure namespaces are lowercase in tags

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -451,11 +451,11 @@ def format_tags(tags):
             namespace = "insights-client"
         if tags_dict.get(namespace) is None:
             tags_dict[namespace] = {}
-        if tags_dict[namespace].get(entry["key"]):
-            tags_dict[namespace][entry["key"]].append(entry["value"])
+        if tags_dict[namespace].get(entry["key"].lower()):
+            tags_dict[namespace][entry["key"].lower()].append(entry["value"].lower())
         else:
-            tags_dict[namespace][entry["key"]] = []
-            tags_dict[namespace][entry["key"]].append(entry["value"])
+            tags_dict[namespace][entry["key"].lower()] = []
+            tags_dict[namespace][entry["key"].lower()].append(entry["value"].lower())
 
     return tags_dict
 

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -446,7 +446,7 @@ def format_tags(tags):
     tags_dict = {}
     for entry in tags:
         if entry.get("namespace"):
-            namespace = entry.pop("namespace")
+            namespace = entry.pop("namespace").lower()
         else:
             namespace = "insights-client"
         if tags_dict.get(namespace) is None:

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,34 @@
+from src.puptoo.process import profile
+
+CLIENT_TAGS = [
+    {"key": "name", "value": "foo", "namespace": "insights-client"},
+    {"key": "zone", "value": "bar", "namespace": "insights-client"},
+    {"key": "location", "value": "nc", "namespace": "insights-client"}
+]
+
+
+SAT_TAGS = [
+        {
+            "namespace": "Satellite",
+            "key": "foo",
+            "value": "bar"
+        },
+        {
+            "namespace": "Satellite",
+            "key": "boop",
+            "value": "beep"
+        }
+]
+
+
+def test_format_tags():
+
+    tags = profile.format_tags(SAT_TAGS)
+    assert type(tags["satellite"]) == dict
+    assert tags["satellite"]["foo"] == ["bar"]
+    assert tags["satellite"]["boop"] == ["beep"]
+    
+    tags = profile.format_tags(CLIENT_TAGS)
+    assert type(tags["insights-client"]) == dict
+    assert tags["insights-client"]["name"] == ["foo"]
+    assert tags["insights-client"]["zone"] == ["bar"]

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,15 +1,15 @@
 from src.puptoo.process import profile
 
 CLIENT_TAGS = [
-    {"key": "name", "value": "foo", "namespace": "insights-client"},
-    {"key": "zone", "value": "bar", "namespace": "insights-client"},
-    {"key": "location", "value": "nc", "namespace": "insights-client"},
+    {"key": "name", "value": "Foo", "namespace": "insights-client"},
+    {"key": "zOne", "value": "bar", "namespace": "insights-client"},
+    {"key": "locAtion", "value": "nc", "namespace": "Insights-client"},
 ]
 
 
 SAT_TAGS = [
-    {"namespace": "Satellite", "key": "foo", "value": "bar"},
-    {"namespace": "Satellite", "key": "boop", "value": "beep"},
+    {"namespace": "satellite", "key": "foo", "value": "bar"},
+    {"namespace": "Satellite", "key": "Boop", "value": "beep"},
 ]
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -3,32 +3,24 @@ from src.puptoo.process import profile
 CLIENT_TAGS = [
     {"key": "name", "value": "foo", "namespace": "insights-client"},
     {"key": "zone", "value": "bar", "namespace": "insights-client"},
-    {"key": "location", "value": "nc", "namespace": "insights-client"}
+    {"key": "location", "value": "nc", "namespace": "insights-client"},
 ]
 
 
 SAT_TAGS = [
-        {
-            "namespace": "Satellite",
-            "key": "foo",
-            "value": "bar"
-        },
-        {
-            "namespace": "Satellite",
-            "key": "boop",
-            "value": "beep"
-        }
+    {"namespace": "Satellite", "key": "foo", "value": "bar"},
+    {"namespace": "Satellite", "key": "boop", "value": "beep"},
 ]
 
 
 def test_format_tags():
 
+    good_tags = {"satellite": {"foo": ["bar"], "boop": ["beep"]}}
     tags = profile.format_tags(SAT_TAGS)
     assert type(tags["satellite"]) == dict
-    assert tags["satellite"]["foo"] == ["bar"]
-    assert tags["satellite"]["boop"] == ["beep"]
-    
+    assert tags == good_tags
+
+    good_tags = {"insights-client": {"name": ["foo"], "zone": ["bar"], "location": ["nc"]}}
     tags = profile.format_tags(CLIENT_TAGS)
     assert type(tags["insights-client"]) == dict
-    assert tags["insights-client"]["name"] == ["foo"]
-    assert tags["insights-client"]["zone"] == ["bar"]
+    assert tags == good_tags


### PR DESCRIPTION
Modify the format_tags() func to ensure that we set the namespace to
lowercase

Signed-off-by: Stephen Adams <tsadams@gmail.com>