### PR TITLE
[fix] Handle situation where HDB is a list

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -171,7 +171,10 @@ def system_profile(
 
     if hdb_version:
         try:
-            profile["sap_version"] = hdb_version.version
+            if type(hdb_version) == list:
+                profile["sap_version"] = hdb_version[0].version
+            else:
+                profile["sap_version"] = hdb_version.version
         except Exception as e:
             catch_error("hdb_version", e)
             raise


### PR DESCRIPTION
The HDB parser can sometimes present the data as a list and we need to
be able to handle situations where that happens

RHCLOUD-13341