### PR TITLE
[fix] set insights-client tags to empty by default

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -116,7 +116,7 @@ def system_profile(
     Note that we strip all keys with the value of "None". Inventory service
     ignores any key with None as the value.
     """
-    profile = {"tags": {}}
+    profile = {"tags": {"insights-client": {}}}
 
     if uname:
         try:


### PR DESCRIPTION
In order to wipe out tags when insights-client sends nothing,
we want to ensure that we send the empty dictionary so the tags go away.

RHCLOUD-13307

Signed-off-by: Stephen Adams <tsadams@gmail.com>