### PR TITLE
[fix] set display_name and ansible_host from metadata

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -194,6 +194,9 @@ def handle_message(msg):
                 facts["system_profile"]["owner_id"] = owner_id
             if facts["system_profile"].get("is_ros"):
                 msg["is_ros"] = "true"
+        # Override archive hostname with name provided by client metadata
+        facts["display_name"] = msg["metadata"].get("display_name")
+        facts["ansible_host"] = msg["metadata"].get("ansible_host")
         send_message(
             config.INVENTORY_TOPIC, msgs.inv_message("add_host", facts, msg), extra
         )

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -665,6 +665,8 @@ def get_system_profile(path=None):
 def postprocess(facts):
     if facts["system_profile"].get("display_name"):
         facts["display_name"] = facts["system_profile"].get("display_name")
+    if facts["system_profile"].get("ansible_host"):
+        facts["ansible_host"] = facts["system_profile"].get("ansible_host")
     if facts["system_profile"].get("satellite_id"):
         facts["satellite_id"] = facts["system_profile"].get("satellite_id")
     if facts["system_profile"].get("tags"):


### PR DESCRIPTION
If we get a display_name or ansible hostname from metadata, we should
use it rather than the one we grab out of the archive. If it exists in
metadata, then the customer has set that manually and it should be
preferred.

Signed-off-by: Stephen Adams <tsadams@gmail.com>