### PR TITLE
Fix TB when processing aarch64 system profile

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -209,7 +209,8 @@ def system_profile(
 
     if lscpu:
         try:
-            profile["cores_per_socket"] = int(lscpu.info.get("Cores per socket"))
+            cores_per_socket = lscpu.info.get("Cores per socket")
+            profile["cores_per_socket"] = int(cores_per_socket) if cores_per_socket else None
         except Exception as e:
             catch_error("lscpu", e)
             raise

--- a/tests/test_lscpu.py
+++ b/tests/test_lscpu.py
@@ -28,8 +28,33 @@ L2 cache:              4096K
 NUMA node0 CPU(s):     0,1
 """.strip()
 
+LSCPU_2 = """
+Architecture:        aarch64
+Byte Order:          Little Endian
+CPU(s):              4
+On-line CPU(s) list: 0-3
+Thread(s) per core:  1
+Core(s) per cluster: 4
+Socket(s):           1
+Cluster(s):          1
+NUMA node(s):        1
+Vendor ID:           ARM
+BIOS Vendor ID:      QEMU
+Model:               1
+Model name:          Neoverse-N1
+BIOS Model name:     virt-4.2
+Stepping:            r3p1
+BogoMIPS:            50.00
+NUMA node0 CPU(s):   0-3
+Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
+""".strip()
+
 
 def test_lscpu():
     input_data = InputData().add(Specs.lscpu, LSCPU_1)
     result = run_test(system_profile, input_data)
     assert result["cores_per_socket"] == 1
+
+    input_data = InputData().add(Specs.lscpu, LSCPU_2)
+    result = run_test(system_profile, input_data)
+    assert result.get("cores_per_socket") is None


### PR DESCRIPTION
lscpu output on my aarch64 VM doesn't contain 'Cores per socket' line and puptoo throws a TB. There is 'Cores per cluster' instead.

https://github.com/karelzak/util-linux/blob/4cae2104ec88890e649b950283fe20af91e9c642/sys-utils/lscpu.c#L876

It would be better to support 'Cores per cluster' better, but it'd need more changes, also in frontend. At least fix the TB for now.