### PR TITLE
[fix] clean invalid mac addresses

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -46,6 +46,12 @@ def get_owner(ident):
         return owner_id
 
 
+def clean_macs(facts):
+    if facts.get("mac_addresses"):
+        facts["mac_addresses"] = [mac for mac in facts["mac_addresses"] if mac != "0.0.0.0"]
+    return facts
+
+
 producer = None
 
 running = True
@@ -189,6 +195,7 @@ def handle_message(msg):
     if facts:
         facts["stale_timestamp"] = get_staletime()
         facts["reporter"] = "puptoo"
+        clean_macs(facts)
         if facts.get("system_profile"):
             if owner_id:
                 facts["system_profile"]["owner_id"] = owner_id

--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -47,8 +47,8 @@ def get_owner(ident):
 
 
 def clean_macs(facts):
-    if facts.get("mac_addresses"):
-        facts["mac_addresses"] = [mac for mac in facts["mac_addresses"] if mac != "0.0.0.0"]
+    if facts["metadata"].get("mac_addresses"):
+        facts["metadata"]["mac_addresses"] = [mac for mac in facts["metadata"]["mac_addresses"] if mac != "0.0.0.0"]
     return facts
 
 
@@ -195,7 +195,8 @@ def handle_message(msg):
     if facts:
         facts["stale_timestamp"] = get_staletime()
         facts["reporter"] = "puptoo"
-        clean_macs(facts)
+        if facts.get("metadata"):
+            clean_macs(facts)
         if facts.get("system_profile"):
             if owner_id:
                 facts["system_profile"]["owner_id"] = owner_id

--- a/tests/test_clean_macs.py
+++ b/tests/test_clean_macs.py
@@ -1,18 +1,18 @@
 from src.puptoo.app import clean_macs
 
 
-GOOD_MACS = {"mac_addresses": ["52:54:00:fd:be:d0",
-             "b4:6b:fc:9e:ae:0d"]}
+GOOD_MACS = {"metadata": {"mac_addresses": ["52:54:00:fd:be:d0",
+             "b4:6b:fc:9e:ae:0d"]}}
 
-BAD_MACS = {"mac_addresses": ["0.0.0.0",
+BAD_MACS = {"metadata": {"mac_addresses": ["0.0.0.0",
             "52:54:00:fd:be:d0",
              "b4:6b:fc:9e:ae:0d",
-             "0.0.0.0"]}
+             "0.0.0.0"]}}
 
 
 def test_clean_macs():
     result = clean_macs(GOOD_MACS)
-    assert result["mac_addresses"] == ["52:54:00:fd:be:d0", "b4:6b:fc:9e:ae:0d"]
+    assert result["metadata"]["mac_addresses"] == ["52:54:00:fd:be:d0", "b4:6b:fc:9e:ae:0d"]
 
     result = clean_macs(BAD_MACS)
-    assert result["mac_addresses"] == ["52:54:00:fd:be:d0", "b4:6b:fc:9e:ae:0d"]
+    assert result["metadata"]["mac_addresses"] == ["52:54:00:fd:be:d0", "b4:6b:fc:9e:ae:0d"]

--- a/tests/test_clean_macs.py
+++ b/tests/test_clean_macs.py
@@ -1,0 +1,18 @@
+from src.puptoo.app import clean_macs
+
+
+GOOD_MACS = {"mac_addresses": ["52:54:00:fd:be:d0",
+             "b4:6b:fc:9e:ae:0d"]}
+
+BAD_MACS = {"mac_addresses": ["0.0.0.0",
+            "52:54:00:fd:be:d0",
+             "b4:6b:fc:9e:ae:0d",
+             "0.0.0.0"]}
+
+
+def test_clean_macs():
+    result = clean_macs(GOOD_MACS)
+    assert result["mac_addresses"] == ["52:54:00:fd:be:d0", "b4:6b:fc:9e:ae:0d"]
+
+    result = clean_macs(BAD_MACS)
+    assert result["mac_addresses"] == ["52:54:00:fd:be:d0", "b4:6b:fc:9e:ae:0d"]


### PR DESCRIPTION
There has been a report that we get invalid mac addresses through
canonical facts. We need to clean out certain mac_addresses that are not
valid so we can pass inventory schema.

Signed-off-by: Stephen Adams <tsadams@gmail.com>