### PR TITLE
[fix] add xz and bzip2 to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.redhat.io/ubi8/ubi-minimal
 WORKDIR /app-root/
-RUN microdnf install -y python36 python3-devel curl python3-pip git tar xz bzip2 && \
+RUN microdnf install -y python36 python3-devel curl python3-pip git tar xz bzip2 unzip && \
     git clone -b 3.0 https://github.com/RedHatInsights/insights-core && \
     pip3 install ./insights-core
 COPY src src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.redhat.io/ubi8/ubi-minimal
 WORKDIR /app-root/
-RUN microdnf install -y python36 python3-devel curl python3-pip git tar && \
+RUN microdnf install -y python36 python3-devel curl python3-pip git tar xz bzip2 && \
     git clone -b 3.0 https://github.com/RedHatInsights/insights-core && \
     pip3 install ./insights-core
 COPY src src


### PR DESCRIPTION
Puptoo needs to have these in the image in order to extract these types
of files.

Signed-off-by: Stephen Adams <tsadams@gmail.com>