### PR TITLE
[fix] mistyped sasl mechanism config

### DIFF
--- a/src/puptoo/mq/consume.py
+++ b/src/puptoo/mq/consume.py
@@ -21,7 +21,7 @@ def init_consumer():
             connection_info.update(
                 {
                     "security.protocol": "sasl_ssl",
-                    "sasl.mechanism": "SCRAM-SHA-512",
+                    "sasl.mechanisms": "SCRAM-SHA-512",
                     "sasl.username": config.KAFKA_BROKER.sasl.username,
                     "sasl.password": config.KAFKA_BROKER.sasl.password,
                 }

--- a/src/puptoo/mq/produce.py
+++ b/src/puptoo/mq/produce.py
@@ -15,7 +15,7 @@ def init_producer():
             connection_info.update(
                 {
                     "security.protocol": "sasl_ssl",
-                    "sasl.mechanism": "SCRAM-SHA-512",
+                    "sasl.mechanisms": "SCRAM-SHA-512",
                     "sasl.username": config.KAFKA_BROKER.sasl.username,
                     "sasl.password": config.KAFKA_BROKER.sasl.password,
                 }


### PR DESCRIPTION
sasl.mechanisms should be plural

Signed-off-by: Stephen Adams <tsadams@gmail.com>