### PR TITLE
[bug] Fix crash when mac address is "none"

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -657,10 +657,12 @@ def _safe_fetch_interface_field(interface, field_name):
 
 
 def _filter_macs(mac):
-
-    m = re.compile(MAC_REGEX)
-    if m.match(mac):
-        return mac
+    if mac:
+        m = re.compile(MAC_REGEX)
+        if m.match(mac):
+            return mac
+        else:
+            return None
     else:
         return None
 


### PR DESCRIPTION
An edge case where mac address is "none" would cuase puptoo to fail the
archive. We now check for that and handle it

Signed-off-by: Stephen Adams <tsadams@gmail.com>