### PR TITLE
[fix] filter bad macs from canonical facts

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -1,5 +1,6 @@
 import json
 import signal
+import re
 from datetime import datetime, timedelta
 from functools import partial
 from time import time
@@ -9,6 +10,7 @@ from confluent_kafka import KafkaError
 from prometheus_client import Info, Summary, start_http_server
 
 from .process import extract
+from .process.profile import MAC_REGEX
 from .mq import consume, msgs, produce
 from .utils import config, metrics, puptoo_logging
 from .utils.puptoo_logging import threadctx
@@ -53,7 +55,8 @@ def get_owner(ident):
 
 def clean_macs(facts):
     if facts["metadata"].get("mac_addresses"):
-        facts["metadata"]["mac_addresses"] = [mac for mac in facts["metadata"]["mac_addresses"] if mac != "0.0.0.0"]
+        m = re.compile(MAC_REGEX)
+        facts["metadata"]["mac_addresses"] = [mac for mac in facts["metadata"]["mac_addresses"] if m.match(mac)]
     return facts
 
 

--- a/tests/test_clean_macs.py
+++ b/tests/test_clean_macs.py
@@ -7,7 +7,8 @@ GOOD_MACS = {"metadata": {"mac_addresses": ["52:54:00:fd:be:d0",
 BAD_MACS = {"metadata": {"mac_addresses": ["0.0.0.0",
             "52:54:00:fd:be:d0",
              "b4:6b:fc:9e:ae:0d",
-             "0.0.0.0"]}}
+             "0.0.0.0",
+             "00:00:00:00"]}}
 
 
 def test_clean_macs():


### PR DESCRIPTION
Match mac addresses against regex to prevent bad macs from making it
into inventory via canonical facts

Signed-off-by: Stephen Adams <tsadams@gmail.com>