### PR TITLE
Some of the metrics appear to be getting counted twice.

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -124,7 +124,6 @@ def main():
 def process_archive(msg, extra):
     facts = extract(msg, extra)
     if facts.get("error"):
-        metrics.extract_failure.inc()
         send_message(
             config.TRACKER_TOPIC,
             msgs.tracker_message(extra, "error", "Unable to extract facts"),

--- a/src/puptoo/process/__init__.py
+++ b/src/puptoo/process/__init__.py
@@ -37,8 +37,6 @@ def unpacked_archive(msg, remove=True):
     Simple ContextManager which is used to for automatically downloading + unpacking
     insights archive, and performing cleanup when needed.
     """
-    metrics.extraction_count.inc()
-
     with NamedTemporaryFile(delete=remove) as tf:
         tf.write(get_archive(msg["url"]))
         tf.flush()
@@ -52,6 +50,7 @@ def extract(msg, extra, remove=True):
     Perform the extraction of canonical system facts and system profile.
     """
     facts = {"system_profile": {}}
+    metrics.attempted_extraction_count.inc()
     with unpacked_archive(msg, remove) as unpacked:
         try:
             validate_size(unpacked.tmp_dir)
@@ -64,6 +63,5 @@ def extract(msg, extra, remove=True):
             return facts
 
         facts = postprocess(facts)
-        metrics.msg_processed.inc()
         metrics.extract_success.inc()
         return facts

--- a/src/puptoo/utils/metrics.py
+++ b/src/puptoo/utils/metrics.py
@@ -14,7 +14,7 @@ msg_count = Counter(
 failed_msg_count = Counter(
     "puptoo_messages_consume_failure_total", "Total messages that failed to be consumed"
 )
-extraction_count = Counter(
+attempted_extraction_count = Counter(
     "puptoo_extractions_total", "Total archive extractions attempted"
 )
 extract_failure = Counter(
@@ -22,9 +22,6 @@ extract_failure = Counter(
 )
 extract_success = Counter(
     "puptoo_successful_extractions_total", "Total archives successfully extracted"
-)
-msg_processed = Counter(
-    "puptoo_messages_processed_total", "Total messages successful process"
 )
 msg_produced = Counter(
     "puptoo_messages_produced_total", "Total messages produced", ["topic"]


### PR DESCRIPTION
metrics.msg_processed.inc() and metrics.extract_success.inc() appear to be getting called twice.  Also, it looks like those metrics are getting called in the success and failure cases.

On exception, the logic is falling through to the postprocess method
which assumes that the system_profile section of the facts will be
populated.  I don't think you want to call postprocess unless the
extraction was successful.