### PR TITLE
[task] add check for anemic tentants

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -110,6 +110,10 @@ def main():
                     service = service.decode("utf-8")
                     if service in ['advisor', 'compliance', 'malware-detection']:
                         msg = json.loads(msg.value().decode("utf-8"))
+                        # TODO: remove this check when inventory is ready for
+                        # anemic (ie account-less) tenants.
+                        if not msg.get("account"):
+                            pass
                         handle_message(msg, service)
             except Exception:
                 consumer.commit()


### PR DESCRIPTION
Since puptoo is running on the new ingress `announce` topic, we need to
make sure that it doesn't accept anemic tenants until the downstream is
ready for them. The announce topic could potentially send an account
without an EBS account number and currently most downstream services
require it.

This check can be removed when the full support is available downstream.

Signed-off-by: Stephen Adams <tsadams@gmail.com>