### PR TITLE
ESSNTL-2766 handle anemic-tenants

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -112,9 +112,8 @@ def main():
                         msg = json.loads(msg.value().decode("utf-8"))
                         # TODO: remove this check when inventory is ready for
                         # anemic (ie account-less) tenants.
-                        if not msg.get("account"):
-                            pass
-                        handle_message(msg, service)
+                        if msg.get("account"):
+                           handle_message(msg, service)
             except Exception:
                 consumer.commit()
                 logger.exception("An error occurred during message processing")


### PR DESCRIPTION
Since puptoo is running on the new ingress announce topic, we need to
make sure that it doesn't accept anemic tenants until the downstream is
ready for them. The announce topic could potentially send an account
without an EBS account number and currently most downstream services
require it.

This check can be removed when the full support is available downstream.