### PR TITLE
make kafka config pull values from clowder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ prometheus-client = "0.7.1"
 requests = "2.23.0"
 confluent-kafka = "1.5.0"
 insights-core = "^3.0.280"
-app-common-python = "0.2.2"
+app-common-python = "0.2.3"
 watchtower = "^1.0.6"
 logstash_formatter = "^0.5.17"
 

--- a/src/puptoo/mq/consume.py
+++ b/src/puptoo/mq/consume.py
@@ -20,8 +20,8 @@ def init_consumer():
         if config.KAFKA_BROKER.sasl and config.KAFKA_BROKER.sasl.username:
             connection_info.update(
                 {
-                    "security.protocol": "sasl_ssl",
-                    "sasl.mechanisms": "SCRAM-SHA-512",
+                    "security.protocol":config.KAFKA_BROKER.sasl.securityProtocol,
+                    "sasl.mechanisms": config.KAFKA_BROKER.sasl.saslMechanism,
                     "sasl.username": config.KAFKA_BROKER.sasl.username,
                     "sasl.password": config.KAFKA_BROKER.sasl.password,
                 }

--- a/src/puptoo/mq/produce.py
+++ b/src/puptoo/mq/produce.py
@@ -14,8 +14,8 @@ def init_producer():
         if config.KAFKA_BROKER.sasl and config.KAFKA_BROKER.sasl.username:
             connection_info.update(
                 {
-                    "security.protocol": "sasl_ssl",
-                    "sasl.mechanisms": "SCRAM-SHA-512",
+                    "security.protocol":config.KAFKA_BROKER.sasl.securityProtocol,
+                    "sasl.mechanisms": config.KAFKA_BROKER.sasl.saslMechanism,
                     "sasl.username": config.KAFKA_BROKER.sasl.username,
                     "sasl.password": config.KAFKA_BROKER.sasl.password,
                 }


### PR DESCRIPTION
The sasl config needs to use the clowder config for the mechanism and
protocol

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>