### PR TITLE
[ESSNTL-3550] Cast tags as expected string values

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -566,14 +566,14 @@ def format_tags(tags):
         if tags_dict.get(namespace) is None:
             tags_dict[namespace] = {}
         if tags_dict[namespace].get(entry["key"]):
-            if isinstance(entry["value"], str):
-                tags_dict[namespace][entry["key"]].append(entry["value"])
+            value_str = str(entry["value"])
+            tags_dict[namespace][entry["key"]].append(value_str)
         else:
             if entry["value"] is None:
                 tags_dict[namespace][entry["key"]] = []
-            if isinstance(entry["value"], str):
-                tags_dict[namespace][entry["key"]] = []
-                tags_dict[namespace][entry["key"]].append(entry["value"])
+            value_str = str(entry["value"])
+            tags_dict[namespace][entry["key"]] = []
+            tags_dict[namespace][entry["key"]].append(value_str)
 
     return tags_dict
 


### PR DESCRIPTION
PR addresses [ESSNTL-3550](https://issues.redhat.com/browse/ESSNTL-3550).

Instead of checking for string instances and ignoring other tags input, cast tags input as string for better user experience as numbers will not need to be wrapped in quotations when strings already do not need to be wrapped.

If there is a reason we would prefer not to do this, then we should alert the user with an appropriate error message instead as, though it is [documented](https://consoledot.pages.redhat.com/docs/dev/services/inventory.html#host-tags), it is not clear to users when in the process of adding tags.