### PR TITLE
[ESSNTL-3568] Allow tags value null

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -566,13 +566,17 @@ def format_tags(tags):
         if tags_dict.get(namespace) is None:
             tags_dict[namespace] = {}
         if tags_dict[namespace].get(entry["key"]):
-            value_str = str(entry["value"])
+            if entry["value"] is None:
+                value_str = None
+            else:
+                value_str = str(entry["value"])
             tags_dict[namespace][entry["key"]].append(value_str)
         else:
-            if entry["value"] is None:
-                tags_dict[namespace][entry["key"]] = []
-            value_str = str(entry["value"])
             tags_dict[namespace][entry["key"]] = []
+            if entry["value"] is None:
+                value_str = None
+            else:
+                value_str = str(entry["value"])
             tags_dict[namespace][entry["key"]].append(value_str)
 
     return tags_dict

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -567,13 +567,6 @@ def format_tags(tags):
             tags_dict[namespace] = {}
         if tags_dict[namespace].get(entry["key"]):
             if entry["value"] is None:
-                value_str = None
-            else:
-                value_str = str(entry["value"])
-            tags_dict[namespace][entry["key"]].append(value_str)
-        else:
-            tags_dict[namespace][entry["key"]] = []
-            if entry["value"] is None:
                 tags_dict[namespace][entry["key"]] = []
             else:
                 value_str = str(entry["value"])

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -574,6 +574,11 @@ def format_tags(tags):
         else:
             tags_dict[namespace][entry["key"]] = []
             if entry["value"] is None:
+                tags_dict[namespace][entry["key"]] = []
+            else:
+                value_str = str(entry["value"])
+                tags_dict[namespace][entry["key"]].append(value_str)
+
                 value_str = None
             else:
                 value_str = str(entry["value"])

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -579,11 +579,6 @@ def format_tags(tags):
                 value_str = str(entry["value"])
                 tags_dict[namespace][entry["key"]].append(value_str)
 
-                value_str = None
-            else:
-                value_str = str(entry["value"])
-            tags_dict[namespace][entry["key"]].append(value_str)
-
     return tags_dict
 
 


### PR DESCRIPTION
With the recent change in https://github.com/RedHatInsights/insights-puptoo/pull/230 to cast tags as strings for better user experience around integer values, null values are now converted to string "None".

Instead, we should check for null values and use them and only cast to string in non-null cases.

This issue was reported here:
https://issues.redhat.com/browse/ESSNTL-3568