### PR TITLE
fix: prefix storage key config options

### DIFF
--- a/src/puptoo/upload.py
+++ b/src/puptoo/upload.py
@@ -9,7 +9,7 @@ logger = puptoo_logging.initialize_logging()
 # Minio client setup and upload yum_updates object
 def upload_object(yum_updates, extra, msg):
     _bytes = json.dumps(yum_updates).encode("utf-8")
-    client = Minio(endpoint=config.S3_ENDPOINT, access_key=config.ACCESS_KEY, secret_key=config.SECRET_KEY, secure=config.USE_SSL)
+    client = Minio(endpoint=config.S3_ENDPOINT, access_key=config.AWS_ACCESS_KEY, secret_key=config.AWS_SECRET_KEY, secure=config.USE_SSL)
     if client.bucket_exists(config.BUCKET_NAME):
         try:
             client.put_object(bucket_name=config.BUCKET_NAME, object_name=extra["request_id"], data=io.BytesIO(_bytes), length=len(_bytes))

--- a/src/puptoo/utils/config.py
+++ b/src/puptoo/utils/config.py
@@ -48,8 +48,8 @@ if CLOWDER_ENABLED:
     # Storage secrets
     BUCKET_NAME = os.getenv("PUPTOO_BUCKET", LoadedConfig.objectStore.buckets[0].requestedName)
     S3_ENDPOINT = os.getenv("S3_ENDPOINT", LoadedConfig.objectStore.hostname)
-    ACCESS_KEY = os.getenv("STORAGE_ACCESS_KEY", LoadedConfig.objectStore.buckets[0].accessKey)
-    SECRET_KEY = os.getenv("STORAGE_SECRET_KEY", LoadedConfig.objectStore.buckets[0].secretKey)
+    AWS_ACCESS_KEY = os.getenv("STORAGE_ACCESS_KEY", LoadedConfig.objectStore.buckets[0].accessKey)
+    AWS_SECRET_KEY = os.getenv("STORAGE_SECRET_KEY", LoadedConfig.objectStore.buckets[0].secretKey)
     USE_SSL = os.getenv("USE_SSL", True)
 
 else:


### PR DESCRIPTION
We should add `AWS` to the storage config option variables in order to
ensure they these keys do not get printed to the logs on startup. The
following function removes any AWS related keys from the config
printout.

[config.py](https://github.com/RedHatInsights/insights-puptoo/blob/945dd86cbac1f563602e70c8d593e8b180a9c5cd/src/puptoo/utils/config.py#L16)

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>
