### PR TITLE
feat: gather releasever and basearch

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -545,6 +545,11 @@ def system_profile(
             catch_error("yum_updates", e)
             raise
 
+        # Add general facts to global system profile, as yum_updates is large
+        if type(profile["yum_updates"]) == dict:
+            profile["releasever"] = profile["yum_updates"].get("releasever")
+            profile["basearch"] = profile["yum_updates"].get("basearch")
+
     if pmlog_summary or ros_config:
         profile["is_ros"] = True
 


### PR DESCRIPTION
**Depends on https://github.com/RedHatInsights/inventory-schemas/pull/99**

Gathers `releasever` and `basearch` facts to system profile from `yum_updates`.

 This is to properly identify YUM repository URLs. Especially those that
have `$releasever` and `$basearch` placeholders.

Note, that these two facts are already present in `yum_updates` JSON. However, the `yum_updates` requires additional parsing, hence this information should be globally present on system profile.

VULN-2456