### PR TITLE
Update pr check to run tests from iqe-puptoo-plugin

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -10,7 +10,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     testing:
-      iqePlugin: e2e
+      iqePlugin: puptoo
     optionalDependencies:
     - ingress
     - storage-broker

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,7 +7,7 @@ APP_NAME="ingress"  # name of app-sre "application" folder this component lives 
 COMPONENT_NAME="puptoo"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/insights-puptoo"
 
-IQE_PLUGINS="e2e"
+IQE_PLUGINS="puptoo"
 IQE_MARKER_EXPRESSION="smoke"
 IQE_FILTER_EXPRESSION=""
 IQE_CJI_TIMEOUT="30m"


### PR DESCRIPTION
We are archiving the iqe-e2e-plugin so the smoke tests we run as part of the PR CHECK job for puptoo have been moved to a new plugin: iqe-puptoo-plugin. This MR updates the PR_CHECK script to start using iqe-puptoo-plugin.