### PR TITLE
fix: Redis flag modification

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -125,4 +125,4 @@ parameters:
   value: $STORAGE_SECRET_KEY
 - name: DISABLE_REDIS
   description: Turn off Redis if necessary
-  value: False
+  value: "False"

--- a/src/puptoo/utils/config.py
+++ b/src/puptoo/utils/config.py
@@ -84,4 +84,4 @@ KAFKA_QUEUE_MAX_KBYTES = os.getenv("KAFKA_QUEUE_MAX_KBYTES", 1024)
 KAFKA_AUTO_COMMIT = os.getenv("KAFKA_AUTO_COMMIT", False)
 KAFKA_ALLOW_CREATE_TOPICS = os.getenv("KAFKA_ALLOW_CREATE_TOPICS", False)
 KAFKA_LOGGER = os.getenv("KAFKA_LOGGER", "ERROR").upper()
-DISABLE_REDIS = os.getenv("DISABLE_REDIS", False)
+DISABLE_REDIS = True if os.getenv("DISABLE_REDIS").lower() == "true" else False


### PR DESCRIPTION
Because of the way templates work, any string would evaluate to true. We need to check for the specific "true" flag