### PR TITLE
chore: bump requests from 2.31.0 to 2.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "~3.8"
 prometheus-client = "0.7.1"
-requests = "2.31.0"
+requests = "2.32.0"
 confluent-kafka = "1.5.0"
 insights-core = "3.3.19"
 app-common-python = "0.2.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pytest==5.4.3
 python-dateutil==2.8.1
 PyYAML==5.4.1
 redis==4.4.4
-requests==2.31.0
+requests==2.32.0
 six==1.15.0
 urllib3==1.26.5
 wcwidth==0.2.5


### PR DESCRIPTION
vulnerability mitigation for image `SECURITY SCAN` in quay.io, related to RHINENG-10128 