### PR TITLE
fix: bump up versions of jinja2 and MarkupSafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,10 @@ flake8==3.8.4
 freezegun==0.3.15
 idna==3.7
 insights-core==3.3.28
-Jinja2==2.11.3
+Jinja2==3.1.4
 jsonschema==3.2.0
 lockfile==0.12.2
-MarkupSafe==1.1.1
+MarkupSafe==2.1.5
 mccabe==0.6.1
 more-itertools==8.6.0
 msgpack==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pytest==5.4.3
 python-dateutil==2.8.1
 PyYAML==5.4.1
 redis==4.4.4
-requests==2.32.0
+requests==2.32.2
 six==1.15.0
 urllib3==1.26.19
 wcwidth==0.2.5


### PR DESCRIPTION
Resolve package conflicts of `jinja2` bumping up in https://github.com/RedHatInsights/insights-puptoo/pull/336 CI Jenkins [run](https://ci.int.devshift.net/job/RedHatInsights-insights-puptoo-pr-check/362/console):  (Cover changes of https://github.com/RedHatInsights/insights-puptoo/pull/336)
```
10:57:32 ERROR: Cannot install MarkupSafe==1.1.1 and jinja2==3.1.4 because these package versions have conflicting dependencies.
10:57:32 
10:57:32 The conflict is caused by:
10:57:32     The user requested MarkupSafe==1.1.1
10:57:32     jinja2 3.1.4 depends on MarkupSafe>=2.0
```


Also, resolve the dependency conflicts of `requests` seeing in this [run](https://ci.int.devshift.net/job/RedHatInsights-insights-puptoo-pr-check/361/console):
```
10:36:29 ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
10:36:29 insights-puptoo 0.1.0 requires requests==2.32.2, but you have requests 2.32.0 which is incompatible.
```