### PR TITLE
fix: use the base image from registry.access.redhat.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 WORKDIR /app-root/
 


### PR DESCRIPTION
To fix the error in https://github.com/RedHatInsights/insights-puptoo/pull/343/checks

ERROR: failed to solve: [registry.redhat.io/ubi8/ubi-minimal](http://registry.redhat.io/ubi8/ubi-minimal): failed to resolve source metadata for [registry.redhat.io/ubi8/ubi-minimal:latest](http://registry.redhat.io/ubi8/ubi-minimal:latest): failed to authorize: failed to fetch anonymous token: unexpected status from GET request


Using  [registry.access.redhat.com](http://registry.access.redhat.com/) as this repo do not need authorize.
