### PR TITLE
chore: use py3.11 as base for dev Dockerfiles

### DIFF
--- a/dev/io_test/consumer/Dockerfile
+++ b/dev/io_test/consumer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 WORKDIR /usr/src/app
 

--- a/dev/io_test/producer/Dockerfile
+++ b/dev/io_test/producer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
- RHINENG-13513 
- This update is driven by the snyk vulnerability scanning fixes.