### PR TITLE
fix: use ubi9 to fix snyk error

### DIFF
--- a/dev/io_test/consumer/Dockerfile
+++ b/dev/io_test/consumer/Dockerfile
@@ -1,5 +1,4 @@
-FROM python:3.13
-
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 WORKDIR /usr/src/app
 

--- a/dev/io_test/producer/Dockerfile
+++ b/dev/io_test/producer/Dockerfile
@@ -1,6 +1,4 @@
-
-FROM python:3.13
-
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Signed-off-by: Lizhong Chen <lichen@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED