### PR TITLE
Revert "RHINENG-2450 Remove logic about the old SAP-related fields"

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -324,26 +324,33 @@ def system_profile(
             raise
 
     if sap:
-        profile["sap"] = {}
-        profile["sap"]["sap_system"] = False
+        profile["sap_system"] = False
         try:
             instances = sap.instances
             if instances:
-                profile["sap"]["sap_system"] = True
+                profile["sap_system"] = True
                 sids = {sap.sid(instance) for instance in instances}
-                profile["sap"]["sids"] = sorted(list(sids))
+                profile["sap_sids"] = sorted(list(sids))
                 inst = instances[0]
-                profile["sap"]["instance_number"] = sap[inst].number
+                profile["sap_instance_number"] = sap[inst].number
+            profile["sap"] = {}
+            profile["sap"]["sap_system"] = profile.get("sap_system")
+            if profile.get("sap_sids"):
+                profile["sap"]["sids"] = profile.get("sap_sids")
+            if profile.get("sap_instance_number"):
+                profile["sap"]["instance_number"] = profile.get("sap_instance_number")
         except Exception as e:
             catch_error("sap", e)
             raise
 
     if hdb_version:
         try:
-            if isinstance(hdb_version, list):
-                profile["sap"]["version"] = hdb_version[0].version
+            if type(hdb_version) == list:
+                profile["sap_version"] = hdb_version[0].version
             else:
-                profile["sap"]["version"] = hdb_version.version
+                profile["sap_version"] = hdb_version.version
+            if profile.get("sap"):
+                profile["sap"]["version"] = profile["sap_version"]
         except Exception as e:
             catch_error("hdb_version", e)
             raise

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -109,9 +109,9 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'instance_number': '88', 'sap_system': True, 'sids': ['D89', 'D90']}
-    assert result["sap"]["sap_system"] == True
-    assert result["sap"]["instance_number"] == '88'
-    assert result["sap"]["sids"] == ['D89', 'D90']
+    assert result["sap_system"] == True
+    assert result["sap_instance_number"] == '88'
+    assert result["sap_sids"] == ['D89', 'D90']
     assert result["sap"] == expected_sap_object
 
 
@@ -121,9 +121,9 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'instance_number': '90', 'sap_system': True, 'sids': ['D90']}
-    assert result["sap"]["sap_system"] == True
-    assert result["sap"]["instance_number"] == '90'
-    assert result["sap"]["sids"] == ['D90']
+    assert result["sap_system"] == True
+    assert result.get("sap_instance_number") == '90'
+    assert result.get("sap_sids") == ['D90']
     assert result["sap"] == expected_sap_object
 
 
@@ -133,7 +133,9 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'sap_system': False}
-    assert result["sap"]["sap_system"] == False
+    assert result["sap_system"] == False
+    assert result.get("sap_instance_number") == None
+    assert result.get("sap_sids") == None
     assert result["sap"] == expected_sap_object
     
 
@@ -143,7 +145,7 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'instance_number': '12', 'sap_system': True, 'sids': ['R4D', 'WDX']}
-    assert result["sap"]["sap_system"] == True
-    assert result["sap"]["instance_number"] == '12'
-    assert result["sap"]["sids"] == ['R4D', 'WDX']
+    assert result["sap_system"] == True
+    assert result["sap_instance_number"] == '12'
+    assert result["sap_sids"] == ['R4D', 'WDX']
     assert result["sap"] == expected_sap_object


### PR DESCRIPTION
This reverts commit a0782b4de68fbf7a892be27dc0d13455cb7d927f.

It breaks Advisor, malware, patch and vulnerability.