### PR TITLE
chore: enhance README.md for test-archive sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ From this nature, this test-archive example can be used for system-profile QA Ve
 
 Tar the provided test-archive example with:
 ```sh
-$ tar -zcvf insights-puptoo-test-archive.tar.gz ./dev/test-archives/core-base
+$ cd ./dev/test-archives
+$ tar -zcvf insights-puptoo-test-archive.tar.gz ./core-base
 ```
 
 ## Deployment


### PR DESCRIPTION
To avoid including the `./dev/test-archives/` directory layers in the generated test-archive. Archive with extra directory layers will result in processing failure in insights-engine service.