### PR TITLE
RHINENG-417: enhance metrics to track for all services

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -123,7 +123,7 @@ def main():
                 continue
             if msg.error():
                 logger.error("Consumer error: %s", msg.error())
-                metrics.failed_msg_count.inc()
+                metrics.kafka_consume_msg_failure_count.inc()
                 continue
 
             now = time()
@@ -275,6 +275,7 @@ def handle_message(msg, service, extra):
             except:
                 logger.exception("Error occurred while uploading object.")
 
+        metrics.msg_success_count.inc()
         send_message(
             config.INVENTORY_TOPIC, msgs.inv_message("add_host", facts, msg), extra
         )

--- a/src/puptoo/utils/metrics.py
+++ b/src/puptoo/utils/metrics.py
@@ -8,12 +8,20 @@ SYSTEM_PROFILE = Summary(
     "puptoo_system_profile_seconds", "Total time spent extracting system profile"
 )
 
+# For messages processed for all services
 msg_count = Counter(
-    "puptoo_messages_consumed_total", "Total messages consumed from the kafka topic"
+    "puptoo_messages_consumed_total", "Total messages processed for all services"
 )
-failed_msg_count = Counter(
+msg_success_count = Counter(
+    "puptoo_messages_consumed_success_total", "Total messages processed successfully for all services"
+)
+
+# For kafka message consume error counter, keep it for back compatibility
+kafka_consume_msg_failure_count = Counter(
     "puptoo_messages_consume_failure_total", "Total messages that failed to be consumed"
 )
+
+# For advisor service archive unpacking
 extraction_count = Counter(
     "puptoo_extractions_total", "Total archive extractions attempted"
 )
@@ -23,14 +31,16 @@ extract_failure = Counter(
 extract_success = Counter(
     "puptoo_successful_extractions_total", "Total archives successfully extracted"
 )
+
+# For messages processed for advisor services only
 msg_processed_count = Counter(
-    "puptoo_messages_processed_total", "Total messages processed"
+    "puptoo_messages_processed_total", "Total messages processed for advisor service"
 )
 msg_processed_failure = Counter(
-    "puptoo_messages_processed_failure_total", "Total messages failed processed."
+    "puptoo_messages_processed_failure_total", "Total messages failed processed for advisor service"
 )
 msg_processed_success = Counter(
-    "puptoo_messages_processed_success_total", "Total messages successful processed."
+    "puptoo_messages_processed_success_total", "Total messages successful processed for advisor service"
 )
 
 msg_produced = Counter(


### PR DESCRIPTION
to enable the success/failure counting on all service types processing with new metrics group:
 - total: `"puptoo_messages_consumed_total"`
 - success:  `"puptoo_messages_consumed_success_total"`
 - failure: do the math with `"puptoo_messages_consumed_total" - "puptoo_messages_consumed_success_total"`