### PR TITLE
ci: update renovate config and add renovate-validator

### DIFF
--- a/.github/workflows/renovate-validator.yaml
+++ b/.github/workflows/renovate-validator.yaml
@@ -1,0 +1,14 @@
+name: renovate-config-validator
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.0.1

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,23 @@
         "github>konflux-ci/mintmaker//config/renovate/renovate.json"
     ],
     "schedule": [
-        "on Monday after 3am and before 10am"
+        "at any time"
     ],
     "ignorePaths": [
-      ".pre-commit-config.yaml"
+        ".pre-commit-config.yaml"
+    ],
+    "packageRules": [
+        {
+            "description": "No auto bump up for insights-core",
+            "matchPackageNames": ["insights-core"],
+            "enabled": false
+        },
+        {
+            "description": "Group minor and patch dependency updates",
+            "matchPackagePatterns": ["*"],
+            "matchUpdateTypes": ["minor", "patch"],
+            "groupName": "all non-major dependencies",
+            "groupSlug": "all-minor-patch"
+        }
     ]
 }
-

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
         },
         {
             "description": "Group minor and patch dependency updates",
-            "matchPackagePatterns": ["*"],
+            "matchPackageNames": ["*"],
             "matchUpdateTypes": ["minor", "patch"],
             "groupName": "all non-major dependencies",
             "groupSlug": "all-minor-patch"


### PR DESCRIPTION
 - update schedual time
 - add packageRules
 - add github action - renovate-validator 

To fix for "No more new auto PRs for tekton updates, and leads to konflux pipeline failure" issue