### PR TITLE
Add the ability to disable s3 uploads

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -271,7 +271,7 @@ def handle_message(msg, service, extra):
             facts["ansible_host"] = msg["metadata"]["ansible_host"]
 
         # Upload yum_updates to s3
-        if yum_updates:
+        if yum_updates and not config.DISABLE_S3_UPLOAD:
             try:
                 upload_object(yum_updates, extra, msg)
             except:

--- a/src/puptoo/utils/config.py
+++ b/src/puptoo/utils/config.py
@@ -93,3 +93,4 @@ KAFKA_ALLOW_CREATE_TOPICS = os.getenv("KAFKA_ALLOW_CREATE_TOPICS", False)
 KAFKA_LOGGER = os.getenv("KAFKA_LOGGER", "ERROR").upper()
 DISABLE_REDIS = True if os.getenv("DISABLE_REDIS", "false").lower() == "true" else False
 REDIS_SSL = True if REDIS_PASSWORD else False
+DISABLE_S3_UPLOAD = True if os.getenv("DISABLE_S3_UPLOAD", "false").lower() == "true" else False


### PR DESCRIPTION
- The upload of yum_updates data to s3 is only used by a specific service, if that service isn't deployed its unnecessary to configure an s3 bucket and store this data as it will not be used.