### PR TITLE
fix: arg passing in CloudWatchLogHandler

### DIFF
--- a/src/puptoo/utils/puptoo_logging.py
+++ b/src/puptoo/utils/puptoo_logging.py
@@ -60,12 +60,15 @@ def initialize_logging():
         boto3_session = Session(aws_access_key_id=aws_access_key_id,
                                 aws_secret_access_key=aws_secret_access_key,
                                 region_name=aws_region_name)
+        boto3_client = boto3_session.client("logs")
 
         # configure logging to use watchtower
-        cw_handler = watchtower.CloudWatchLogHandler(boto3_session=boto3_session,
-                                                  log_group=aws_log_group,
-                                                  stream_name=socket.gethostname(),
-                                                  create_log_group=create_log_group)
+        cw_handler = watchtower.CloudWatchLogHandler(
+            boto3_client=boto3_client,
+            log_group_name=aws_log_group,
+            log_stream_name=socket.gethostname(),
+            create_log_group=create_log_group,
+        )
 
         cw_handler.setFormatter(LogstashFormatterV1())
         cw_handler.addFilter(ContextualFilter())


### PR DESCRIPTION
  After bump up the watchtower and its dependencies versions, the stage
  pod failed to start and log with erorr "unexpected keyword argument
  'boto3_session'". Changelog for watchtower shows that the Boto3
  sessions passing ability was removed since v2.0.0. Fix for the
  watchtower.CloudWatchLogHandler() args passing as we are on v3.4.0.

The former watchtower bump up PR:  https://github.com/RedHatInsights/insights-puptoo/pull/437 

serve RHINENG-11300