### PR TITLE
RHINENG-15771: bootc update_method for image mode systems

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -753,6 +753,8 @@ def system_profile(
                             "cached_image": cached_value.get('image', {}).get('image', ''),
                             "cached_image_digest": cached_value.get('imageDigest', ''),
                         })
+            if profile["bootc_status"].get("booted", {}).get("image_digest"):
+                profile["system_update_method"] = "bootc"
         except Exception as e:
             catch_error("bootc_status", e)
             raise

--- a/tests/test_bootc_status.py
+++ b/tests/test_bootc_status.py
@@ -227,6 +227,43 @@ BOOTC_STATUS_BAD_DATA = """
 }
 """.strip()
 
+BOOTC_STATUS_SPECIAL_DATA = """
+{
+   "apiVersion":"org.containers.bootc/v1alpha1",
+   "kind":"BootcHost",
+   "metadata":{
+      "name":"host"
+   },
+   "spec":{
+      "image":{
+         "image":"192.168.124.1:5000/bootc-insights:latest",
+         "transport":"registry"
+      }
+   },
+   "status":{
+      "staged":null,
+      "rollback":{
+         "image":{
+            "image":{
+               "image":"quay.io/centos-boot/fedora-boot-cloud:eln",
+               "transport":"registry"
+            },
+            "version":"39.20231109.3",
+            "timestamp":null,
+            "imageDigest":"sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0"
+         },
+         "incompatible":false,
+         "pinned":false,
+         "ostree":{
+            "checksum":"56612a5982b7f12530988c970d750f89b0489f1f9bebf9c2a54244757e184dd8",
+            "deploySerial":0
+         }
+      },
+      "type":"bootcHost"
+   }
+}
+""".strip()
+
 
 def test_bootc_status():
     input_data = InputData().add(Specs.bootc_status, BOOTC_STATUS)
@@ -277,4 +314,12 @@ def test_bootc_status():
         "booted": {
             "image": "",
             "image_digest": "sha256:806d77394f96e47cf99b1233561ce970c94521244a2d8f2affa12c3261961223",
+        }}
+
+    input_data = InputData().add(Specs.bootc_status, BOOTC_STATUS_SPECIAL_DATA)
+    result = run_test(system_profile, input_data)
+    assert result["bootc_status"] == {
+        "rollback": {
+            "image": "quay.io/centos-boot/fedora-boot-cloud:eln",
+            "image_digest": "sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0",
         }}

--- a/tests/test_system_update_method.py
+++ b/tests/test_system_update_method.py
@@ -1,11 +1,14 @@
 from insights.specs import Specs
 from insights.tests import InputData, run_test
-from .test_host_type import DATA_0
+from tests.test_bootc_status import BOOTC_STATUS, BOOTC_STATUS_SPECIAL_DATA
+from tests.test_host_type import DATA_0
 
 from src.puptoo.process.profile import system_profile
 
 REDHAT_RELEASE_1 = """Red Hat Enterprise Linux release 8.0"""
 REDHAT_RELEASE_2 = """Red Hat Enterprise Linux release 7.8"""
+REDHAT_RELEASE_3 = """Red Hat Enterprise Linux release 9.4"""
+REDHAT_RELEASE_4 = """Red Hat Enterprise Linux release 10.0"""
 
 
 def test_system_update_method():
@@ -17,7 +20,59 @@ def test_system_update_method():
     result = run_test(system_profile, input_data)
     assert result["system_update_method"] == "yum"
 
+
 def test_edge_system():
     input_data = InputData().add(Specs.rpm_ostree_status, DATA_0)
     result = run_test(system_profile, input_data)
     assert result["host_type"] == "edge"
+    assert "system_update_method" not in result
+
+    input_data = InputData()
+    input_data.add(Specs.redhat_release, REDHAT_RELEASE_3)
+    input_data.add(Specs.rpm_ostree_status, DATA_0)
+    result = run_test(system_profile, input_data)
+    assert result["host_type"] == "edge"
+    assert result["system_update_method"] == "rpm-ostree"
+
+    input_data = InputData()
+    input_data.add(Specs.redhat_release, REDHAT_RELEASE_3)
+    result = run_test(system_profile, input_data)
+    assert result["system_update_method"] == "dnf"
+
+
+def test_bootc_system():
+    input_data = InputData("only_rhrls")
+    input_data.add(Specs.redhat_release, REDHAT_RELEASE_4)
+    result = run_test(system_profile, input_data)
+    assert result["system_update_method"] == "dnf"
+
+    input_data = InputData("only_bootc")
+    input_data.add(Specs.bootc_status, BOOTC_STATUS)
+    result = run_test(system_profile, input_data)
+    assert result["system_update_method"] == "bootc"
+
+    input_data = InputData("both_rhrls_and_bootc_false")
+    input_data.add(Specs.redhat_release, REDHAT_RELEASE_4)
+    input_data.add(Specs.bootc_status, BOOTC_STATUS_SPECIAL_DATA)
+    result = run_test(system_profile, input_data)
+    assert result["system_update_method"] == "dnf"
+
+    input_data = InputData("both_rhrls_and_bootc_true")
+    input_data.add(Specs.redhat_release, REDHAT_RELEASE_4)
+    input_data.add(Specs.bootc_status, BOOTC_STATUS)
+    result = run_test(system_profile, input_data)
+    assert result["system_update_method"] == "bootc"
+
+    input_data = InputData("three_rhrls_and_edge_and_bootc_false")
+    input_data.add(Specs.redhat_release, REDHAT_RELEASE_4)
+    input_data.add(Specs.rpm_ostree_status, DATA_0)
+    input_data.add(Specs.bootc_status, BOOTC_STATUS_SPECIAL_DATA)
+    result = run_test(system_profile, input_data)
+    assert result["system_update_method"] == "rpm-ostree"
+
+    input_data = InputData("three_rhrls_and_edge_and_bootc_true")
+    input_data.add(Specs.redhat_release, REDHAT_RELEASE_4)
+    input_data.add(Specs.rpm_ostree_status, DATA_0)
+    input_data.add(Specs.bootc_status, BOOTC_STATUS)
+    result = run_test(system_profile, input_data)
+    assert result["system_update_method"] == "bootc"


### PR DESCRIPTION
With this feat, `system_profile.system_update_method` would support for the following values: 
- RHEL 6 & 7 - yum
- RHEL 8 & 9 - dnf
- Edge - rpm-ostree
- Image Mode (RHEL AI) - bootc