### PR TITLE
RHINENG-15498: extract canonical_facts and system_profile in one go

### DIFF
--- a/src/puptoo/process/__init__.py
+++ b/src/puptoo/process/__init__.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import requests
 from insights import extract as extract_archive
-from insights.util.canonical_facts import get_canonical_facts
 
 from .profile import get_system_profile, postprocess
 from ..utils import config, metrics
@@ -76,11 +75,11 @@ def extract(msg, extra, remove=True):
 
         try:
             validate_size(unpacked.tmp_dir, extra)
-            facts = get_canonical_facts(unpacked.tmp_dir)
+            # extract canonical_facts and system_profile in one go
+            facts = get_system_profile(unpacked.tmp_dir)
             isValid = validateCanonicalFacts(facts)
             if not isValid:
                 raise Exception("Missing canonical fact(s).")
-            facts['system_profile'] = get_system_profile(unpacked.tmp_dir)
             facts = postprocess(facts)
         except Exception as e:
             logger.exception("Failed to extract facts: %s", str(e), extra=extra)

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -59,6 +59,7 @@ from insights.parsers.uptime import Uptime
 from insights.parsers.yum_repos_d import YumReposD
 from insights.parsers.yum_updates import YumUpdates
 from insights.specs import Specs
+from insights.util.canonical_facts import canonical_facts
 
 from src.puptoo.utils import config, metrics, puptoo_logging
 
@@ -1057,7 +1058,6 @@ def _remove_bad_names(facts, keys):
 
 
 def run_profile():
-
     args = None
 
     import argparse
@@ -1083,10 +1083,13 @@ def run_profile():
 
 @metrics.SYSTEM_PROFILE.time()
 def get_system_profile(path=None):
-    broker = run(system_profile, root=path)
-    result = broker[system_profile]
-    del result["type"]
-    return result
+    rule_components = [canonical_facts, system_profile]
+    broker = run(rule_components, root=path)
+    facts = broker[canonical_facts]
+    del facts["type"]
+    facts['system_profile'] = broker[system_profile]
+    del facts['system_profile']["type"]
+    return facts
 
 
 def postprocess(facts):


### PR DESCRIPTION
  Formerly, the "canonical_facts" and "system_profile" were extracted
  seperately. It is a time waste to calling the insights run() twice.
  Combined to extract these facts in one go.