### PR TITLE
RHINENG-16129: pod exit on kafka consumer poll errors

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -1,4 +1,5 @@
 import json
+import os
 import signal
 import re
 from datetime import datetime, timedelta
@@ -124,7 +125,9 @@ def main():
             if msg.error():
                 logger.error("Consumer error: %s", msg.error())
                 metrics.kafka_consume_msg_failure_count.inc()
-                continue
+                # Known kafka msg error that pod exiting for: SESSTMOUT, MAXPOLL
+                logger.error("Puptoo exiting on kafka consumer poll error to let the pod be recreated!")
+                os._exit(os.EX_SOFTWARE)
 
             now = time()
             CONSUMER_WAIT_TIME.observe(now - start)


### PR DESCRIPTION
  For known consumer poll error cases SESSTMOUT and MAXPOLL. When these
  kafka consumer group connection errors happens, puptoo will break the
  endless loop for continuing msg polling, and exit the process. This
  allows the Kubernetes to recreate a new pod on behalf.