### PR TITLE
chore: add full-stack-mac.yml docker-compose for dev

### DIFF
--- a/dev/full-stack-mac.yml
+++ b/dev/full-stack-mac.yml
@@ -1,0 +1,154 @@
+# This docker-compose file will stand up the entire stack including ingress and inventory.
+# The steps for buidling those images are out of scope, but this will reference them if they exist.
+# This docker compose file will stand up the minimal components necessary for
+# Puptoo to work. Nothing is stood up for uploads or to consume the inventory 
+# messages.
+version: "3"
+services:
+
+  # ### Setup Kafka
+  zookeeper:
+    image: confluentinc/cp-zookeeper
+    environment:
+      - ZOOKEEPER_CLIENT_PORT=32181
+      - ZOOKEEPER_SERVER_ID=1
+  kafka:
+    image: confluentinc/cp-kafka
+    ports:
+      - 29092:29092
+    depends_on:
+      - zookeeper
+    environment:
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092
+      - KAFKA_BROKER_ID=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+  init-kafka:
+    image: confluentinc/cp-kafka
+    depends_on:
+      - kafka
+    entrypoint: [ '/bin/sh', '-c' ]
+    command: |
+      "
+      # blocks until kafka is reachable
+      kafka-topics --bootstrap-server kafka:29092 --list
+
+      echo -e 'Creating kafka topics'
+      kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic platform.upload.advisor --replication-factor 1 --partitions 1
+      kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic platform.upload.announce --replication-factor 1 --partitions 1
+      kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic platform.inventory.host-ingress --replication-factor 1 --partitions 1
+
+      echo -e 'Successfully created the following topics:'
+      kafka-topics --bootstrap-server kafka:29092 --list
+      "
+
+  # ### Setup Storage
+  minio:
+      image: minio/minio
+      command: ["server", "--console-address", ":9001", "/data"]
+      volumes:
+        - '$MINIO_DATA_DIR:/data:Z'
+        - '$MINIO_CONFIG_DIR:/root/.minio:Z'
+      ports:
+        - 9000:9000
+      environment:
+        - MINIO_ROOT_USER=$MINIO_ACCESS_KEY
+        - MINIO_ROOT_PASSWORD=$MINIO_SECRET_KEY
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until (mc alias set myminio http://minio:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY) do echo '...waiting...' && sleep 1; done;
+      mc mb --ignore-existing myminio/insights-upload-perma;
+      mc mb --ignore-existing myminio/insights-upload-rejected;
+      mc mb --ignore-existing myminio/insights-upload-puptoo;
+      mc anonymous set public myminio/insights-upload-perma;
+      mc anonymous set public myminio/insights-upload-rejected;
+      mc anonymous set public myminio/insights-upload-puptoo;
+      exit 0;
+      "
+
+  # ### Setup Ingress
+  ingress:
+    image: quay.io/cloudservices/insights-ingress
+    ports:
+      - 8080:3000
+    environment:
+      - AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY
+      - AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY
+      - AWS_REGION=us-east-1
+      - INGRESS_STAGEBUCKET=insights-upload-perma
+      - INGRESS_REJECTBUCKET=insights-upload-rejected
+      - INGRESS_INVENTORYURL=http://inventory:8080/api/inventory/v1/hosts
+      - INGRESS_VALIDTOPICS=testareno,advisor #if you test a different topic, add it here
+      - INGRESS_VALID_UPLOAD_TYPES=advisor,compliance,hccm,qpc,rhv,tower,leapp-reporting,xavier,mkt,playbook,playbook-sat,resource-optimization,malware-detection,pinakes,assisted-installer,runtimes-java-general,openshift,tasks,automation-hub,aap-billing-controller
+      - OPENSHIFT_BUILD_COMMIT=woopwoop
+      - INGRESS_MINIODEV=true
+      - INGRESS_MINIOACCESSKEY=$MINIO_ACCESS_KEY
+      - INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY
+      - INGRESS_MINIOENDPOINT=minio:9000
+    depends_on:
+      - kafka
+      - minio
+      - createbuckets
+
+  # ### Setup Puptoo
+  puptoo:
+    image: quay.io/cloudservices/insights-puptoo:latest
+    ports:
+      - 8000:8000 #for prometheus endpoint
+    environment:
+      - LOG_LEVEL=DEBUG
+    depends_on:
+      - kafka
+      - init-kafka
+      - minio
+  redis:
+    image: redis
+    container_name: puptoo-redis
+    ports:
+      - 6379:6379
+
+  # ### Setup Puptoo
+  insights-inventory-mq: &inventory
+    image: quay.io/cloudservices/insights-inventory:latest
+    command: "make upgrade_db run_inv_mq_service"
+    environment:
+      - APP_NAME=inventory
+      - PATH_PREFIX=api
+      - INVENTORY_DB_USER=insights
+      - INVENTORY_DB_PASS=insights
+      - INVENTORY_DB_HOST=db-host-inventory
+      - INVENTORY_DB_NAME=insights
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - PAYLOAD_TRACKER_ENABLED=false
+      - PROMETHEUS_MULTIPROC_DIR=/tmp  # required env by insights-inventory-web 
+      - BYPASS_RBAC="true"
+      - BYPASS_UNLEASH="true"
+      - BYPASS_XJOIN="true"
+    depends_on:
+       - db-host-inventory
+       - kafka
+       - init-kafka
+       - createbuckets
+    ports:
+      - "8081:8080"
+  insights-inventory-web:
+    <<: *inventory
+    command: "make upgrade_db run_inv_web_service"
+    depends_on:
+      - insights-inventory-mq
+    ports:
+      - "8082:8080"
+  db-host-inventory:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: insights
+      POSTGRES_USER: insights
+      POSTGRES_DB: insights
+    ports:
+      - "5432:5432"
+


### PR DESCRIPTION
Close RHINENG-19741
- The previous script is not suitable for Mac system testing, would like to add a new file for the mac os system for future local testing

- To run up the puptoo container and its dependency services locally for testing during dev on the Mac system
- To serve testing ticket [RHINENG-19629](https://issues.redhat.com/browse/RHINENG-19629)
- Update the configurations in the Docker file for Minio on the Mac system