### PR TITLE
RHINENG-19627: add "service" label for counter metrics

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -219,7 +219,7 @@ def handle_message(msg, service, extra):
         msgs.tracker_message(extra, "received", "Received message"),
         extra,
     )
-    metrics.msg_processed_count.inc()
+    metrics.msg_processed_count.labels(service).inc()
 
     try:
         # Facts extraction
@@ -298,7 +298,7 @@ def handle_message(msg, service, extra):
             extra,
         )
     else:
-        metrics.msg_processed_success.inc()
+        metrics.msg_processed_success.labels(service).inc()
         send_message(
             config.INVENTORY_TOPIC, msgs.inv_message("add_host", facts, msg), extra
         )

--- a/src/puptoo/utils/metrics.py
+++ b/src/puptoo/utils/metrics.py
@@ -29,11 +29,14 @@ extract_success = Counter(
 
 # For messages processed for all services
 msg_processed_count = Counter(
-    "puptoo_messages_processed_total", "Total messages processed for all service"
+    "puptoo_messages_processed_total",
+    "Total messages processed for all service",
+    ["service"],
 )
 msg_processed_success = Counter(
     "puptoo_messages_processed_success_total",
-    "Total messages processed successfully for all services"
+    "Total messages processed successfully for all services",
+    ["service"],
 )
 msg_processed_failure = Counter(
     "puptoo_messages_processed_failure_total",


### PR DESCRIPTION
- "puptoo_messages_processed_*"

## Summary by Sourcery

Add a 'service' label to message processing metrics and update counter invocations accordingly

Enhancements:
- Add 'service' label to puptoo_messages_processed_total, puptoo_messages_processed_success_total, and puptoo_messages_processed_failure_total counters
- Update metrics.inc() calls to use labels(service).inc() for accurate per-service tracking