### PR TITLE
RHINENG-20053: fix grafana on kafka lag resource change

### DIFF
--- a/dashboards/grafana-dashboard-insights-puptoo-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-puptoo-general.configmap.yaml
@@ -27,8 +27,8 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
+      "id": 886203,
       "links": [],
-      "liveNow": false,
       "panels": [
         {
           "datasource": {
@@ -45,8 +45,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -66,6 +65,8 @@ data:
           },
           "id": 10,
           "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
@@ -75,9 +76,10 @@ data:
               "values": false
             },
             "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "showThresholdMarkers": true,
+            "sizing": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "11.6.3",
           "targets": [
             {
               "datasource": {
@@ -108,8 +110,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -129,6 +130,8 @@ data:
           },
           "id": 8,
           "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
@@ -138,9 +141,10 @@ data:
               "values": false
             },
             "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "showThresholdMarkers": true,
+            "sizing": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "11.6.3",
           "targets": [
             {
               "datasource": {
@@ -158,18 +162,20 @@ data:
         },
         {
           "datasource": {
-            "uid": "${datasource}",
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
+              "decimals": 2,
               "mappings": [],
+              "max": 1,
+              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -177,9 +183,6 @@ data:
                   }
                 ]
               },
-              "decimals": 2,
-              "max": 1,
-              "min": 0,
               "unit": "percentunit"
             },
             "overrides": []
@@ -192,33 +195,33 @@ data:
           },
           "id": 17,
           "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
             "reduceOptions": {
-              "values": false,
               "calcs": [
                 "mean"
               ],
-              "fields": ""
+              "fields": "",
+              "values": false
             },
-            "orientation": "auto",
             "showThresholdLabels": false,
             "showThresholdMarkers": true,
-            "sizing": "auto",
-            "minVizWidth": 75,
-            "minVizHeight": 75
+            "sizing": "auto"
           },
-          "pluginVersion": "10.4.1",
+          "pluginVersion": "11.6.3",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
+              "editorMode": "code",
               "expr": "sum(increase(puptoo_messages_processed_success_total[$__range])) / sum(increase(puptoo_messages_processed_total[$__range]))",
               "interval": "",
               "legendFormat": "",
-              "refId": "A",
-              "editorMode": "code",
-              "range": true
+              "range": true,
+              "refId": "A"
             }
           ],
           "title": "Successful Processed Messages (All Services)",
@@ -236,11 +239,13 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -249,6 +254,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -270,8 +276,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -300,10 +305,12 @@ data:
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.3",
           "targets": [
             {
               "datasource": {
@@ -331,11 +338,13 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "bars",
                 "fillOpacity": 100,
                 "gradientMode": "none",
@@ -344,6 +353,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -366,8 +376,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -396,11 +405,12 @@ data:
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "11.6.3",
           "targets": [
             {
               "datasource": {
@@ -429,11 +439,13 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "bars",
                 "fillOpacity": 100,
                 "gradientMode": "none",
@@ -442,6 +454,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -464,8 +477,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -494,11 +506,12 @@ data:
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "11.6.3",
           "targets": [
             {
               "datasource": {
@@ -518,7 +531,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${datasource_aws}"
           },
           "description": "Messages in the announce topic waiting to be picked up by Puptoo. ",
           "fieldConfig": {
@@ -527,11 +540,13 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -540,6 +555,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -561,8 +577,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -588,48 +603,66 @@ data:
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.3",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${datasource_aws}"
               },
+              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(kafka_consumergroup_group_lag{topic=\"platform.upload.announce\", group=\"insights-puptoo\"}) by (topic)",
+              "expr": "aws_kafka_sum_offset_lag_sum{cluster_name=\"consoledot-prod\", topic=\"platform.upload.announce\", consumer_group=\"insights-puptoo\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
               "legendFormat": "__auto",
               "range": true,
-              "refId": "A"
+              "refId": "A",
+              "useBackend": false
             }
           ],
           "title": "Consumer lag",
           "type": "timeseries"
         }
       ],
-      "schemaVersion": 37,
-      "style": "dark",
+      "preload": false,
+      "refresh": "",
+      "schemaVersion": 41,
       "tags": [],
       "templating": {
         "list": [
           {
             "current": {
-              "selected": false,
               "text": "crcp01ue1-prometheus",
-              "value": "crcp01ue1-prometheus"
+              "value": "PC1EAC84DCBBF0697"
             },
-            "hide": 0,
             "includeAll": false,
             "label": "datasource",
-            "multi": false,
             "name": "datasource",
             "options": [],
             "query": "prometheus",
             "refresh": 1,
             "regex": "/.*crc.*/",
-            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "text": "aws-resources-exporter-production",
+              "value": "PCEFB875D6FD018FC"
+            },
+            "includeAll": false,
+            "label": "datasource_aws",
+            "name": "datasource_aws",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "aws-resources-exporter-.*",
             "type": "datasource"
           }
         ]
@@ -638,25 +671,11 @@ data:
         "from": "now-12h",
         "to": "now"
       },
-      "timepicker": {
-        "refresh_intervals": [
-          "5s",
-          "10s",
-          "30s",
-          "1m",
-          "5m",
-          "15m",
-          "30m",
-          "1h",
-          "2h",
-          "1d"
-        ]
-      },
+      "timepicker": {},
       "timezone": "",
       "title": "Puptoo",
       "uid": "EDPmNcdGk",
-      "version": 2,
-      "weekStart": ""
+      "version": 1
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
kafka-lag-exporter pods decommission requires to replace the usage of
"kafka_consumergroup_group_lag" to "aws_kafka_sum_offset_lag_sum" in
Grafana dashboard.

## Summary by Sourcery

Fix the Grafana dashboard to use the new AWS Kafka lag metric and datasource, update panel plugin versions and defaults, and clean up deprecated dashboard configuration

Bug Fixes:
- Replace kafka_consumergroup_group_lag metric with aws_kafka_sum_offset_lag_sum in the Consumer lag panel

Enhancements:
- Introduce a new AWS Prometheus datasource variable (datasource_aws) and update panels to use it
- Upgrade panel pluginVersion to 11.6.3 and standardize sizing, thresholds, and display defaults

Chores:
- Increment dashboard schemaVersion to 41, remove deprecated fields (liveNow, refresh_intervals, weekStart), and adjust global dashboard settings