### PR TITLE
ci(deps): bump shared konflux-pipelines to v1.39.0

### DIFF
--- a/.tekton/insights-puptoo-pull-request.yaml
+++ b/.tekton/insights-puptoo-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.24.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.39.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo

--- a/.tekton/insights-puptoo-push.yaml
+++ b/.tekton/insights-puptoo-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.24.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.39.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo

--- a/.tekton/puptoo-sc-pull-request.yaml
+++ b/.tekton/puptoo-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.32.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.39.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo-sc

--- a/.tekton/puptoo-sc-push.yaml
+++ b/.tekton/puptoo-sc-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.32.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.39.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo-sc


### PR DESCRIPTION
fix [insights-puptoo-enterprise-contract / insights-puptoo](https://github.com/RedHatInsights/insights-puptoo/pull/520/checks?check_run_id=50560455899) ci error seen in https://github.com/RedHatInsights/insights-puptoo/pull/520 

## Summary by Sourcery

CI:
- Update Tekton pipeline URLs to reference konflux-pipelines v1.39.0 in pull-request and push YAMLs