### PR TITLE
chore: to receive dedicate auto update prs from konflux

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,23 +4,9 @@
     ],
     "baseBranches": ["master"],
     "schedule": [
-        "at any time"
+        "on Monday after 3am and before 10am"
     ],
     "ignorePaths": [
         ".pre-commit-config.yaml"
-    ],
-    "packageRules": [
-        {
-            "description": "No auto bump up for insights-core",
-            "matchPackageNames": ["insights-core"],
-            "enabled": false
-        },
-        {
-            "description": "Group minor and patch dependency updates",
-            "matchPackageNames": ["*"],
-            "matchUpdateTypes": ["minor", "patch"],
-            "groupName": "all non-major dependencies",
-            "groupSlug": "all-minor-patch"
-        }
     ]
 }


### PR DESCRIPTION
- insights shared-pipeline version update
- base image tag update

The konflux auto update prs for the above certain purpose are missing for this repo. 
Turns out the updates are included in pr named [fix(deps): update all non-major dependencies](https://github.com/RedHatInsights/insights-puptoo/pull/445/files#top). 
Updated the `renovate` conf to allow the dedicate pr shows up.

## Summary by Sourcery

Configure Renovate to process dedicated auto-update PRs from Konflux by bumping pipeline version and base image tag

Enhancements:
- Update insights shared-pipeline version in renovate configuration
- Update base image tag in renovate configuration