### PR TITLE
RHINENG-20859: pull system-profile schemas from HBI repo

### DIFF
--- a/unit_test.sh
+++ b/unit_test.sh
@@ -9,12 +9,15 @@ pip install --upgrade pip
 pip install .
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
+
+echo "### Running unit test ..."
 INSIGHTS_FILTERS_ENABLED=false INVENTORY_TOPIC=platform.inventory.host-ingress-p1 ACG_CONFIG=dev/cdappconfig.json pytest tests/ --junitxml=$WORKSPACE/artifacts/junit-unit_tests.xml
 
 if [ $? != 0 ]; then
-   echo "Failed to run unit test"
+   echo ">>> unit test result: FAILURE"
    exit 1
 fi
+echo ">>> unit test result: SUCCESS"
 
 # Clone system-profile schema repo to /tmp
 git clone https://github.com/RedHatInsights/insights-host-inventory.git /tmp/insights-host-inventory
@@ -27,17 +30,23 @@ for file in dev/test-archives/*; do
     # Create tar archive in /tmp
     tar -zcf /tmp/$filename "$file"
     # Run insights-run and output to /tmp/output.json
+    echo "### Running insights-run to populate profile on $file ..."
     insights-run -p src/puptoo -f json /tmp/$filename > /tmp/output.json
     insights-run -p src/puptoo /tmp/$filename # Print results in test console
     if [ $? != 0 ]; then
+        echo ">>> Profile result: FAILURE"
         exit 1
     fi
+    echo ">>> Profile result: SUCCESS"
     OUTPUT_JSON="/tmp/output.json" python3.11 dev/parse_json.py
     # Run schema tester with files in /tmp
+    echo "### Checking output against schema insights-host-inventory/swagger/system_profile.spec.yaml ..."
     python3.11 /tmp/insights-host-inventory/tools/simple-test/tester.py /tmp/insights-host-inventory/swagger/system_profile.spec.yaml /tmp/output.json
     if [ $? != 0 ]; then
+        echo ">>> Schema validation result: FAILURE"
         exit 1
     fi
+    echo ">>> Schema validation result: SUCCESS"
     # Clean up files
     rm /tmp/$filename
     rm /tmp/output.json


### PR DESCRIPTION
Upon the new process for requesting system profile fields, the system
profile schemas source had been moved from inventory-schemas repo to
HBI repo. Adapt the changes here.

## Summary by Sourcery

Adapt the unit test script to pull and validate system-profile schemas from the insights-host-inventory repository instead of the inventory-schemas repo.

Tests:
- Update unit_test.sh to clone the insights-host-inventory repo and invoke the schema tester against swagger/system_profile.spec.yaml
- Update cleanup step to remove the /tmp/insights-host-inventory directory