### PR TITLE
feat(ci): Use remote/shared renovate/mintmaker configuration for Foreman branches - RHINENG-20922

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": [
-        "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+        "github>RedHatInsights/konflux-pipelines//renovate/foreman_satellite/renovate.json"
     ],
     "baseBranchPatterns": [
         "master"
@@ -8,6 +8,9 @@
     "schedule": [
         "on Monday after 3am and before 10am"
     ],
+    "tekton": {
+        "schedule": ["at any time"]
+    },
     "ignorePaths": [
         ".pre-commit-config.yaml"
     ]


### PR DESCRIPTION
## Summary by Sourcery

Switch the repository’s Renovate setup to use the remote/shared renovate/mintmaker configuration for Foreman branches.

Enhancements:
- Remove local Renovate rules and presets from renovate.json in favor of centralized settings

CI:
- Extend Renovate configuration with the remote/shared renovate/mintmaker presets for Foreman branches