### PR TITLE
chore: fix pip setuptools error in Dockerfile.upstream

### DIFF
--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -19,6 +19,6 @@ COPY dev dev
 COPY tests tests
 COPY src src
 
-RUN pip3.11 install --upgrade pip && pip3.11 install .
+RUN pip3.11 install --upgrade pip && pip3.11 install . --ignore-installed
 
 CMD ["puptoo"]


### PR DESCRIPTION
- error: uninstall-no-record-file in image build

error seen in CI "Container image build and publish / build (push)" - https://github.com/RedHatInsights/insights-puptoo/actions/runs/19456979046/job/55672697834

## Summary by Sourcery

Bug Fixes:
- Fix pip setuptools uninstall-no-record-file error in Dockerfile.upstream