### PR TITLE
Standardize konflux-pipelines to main branch

### DIFF
--- a/.tekton/puptoo-sc-pull-request.yaml
+++ b/.tekton/puptoo-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.45.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo-sc

--- a/.tekton/puptoo-sc-push.yaml
+++ b/.tekton/puptoo-sc-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.45.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo-sc


### PR DESCRIPTION
## Summary
- Removed version pinning from konflux-pipelines URL in SC YAML files
- Updated to `main` branch reference

## Changes
Updated all `*-sc-*.yaml` files in `.tekton/` directory

## Reason
Standardizing pipeline references across the platform to use the main branch instead of version-specific URLs.

## Summary by Sourcery

Enhancements:
- Replace version-pinned konflux-pipelines URLs with main branch references in security-compliance Tekton YAML files