### PR TITLE
chore: fix pip setuptools error in Dockerfile.upstream (foreman)

### DIFF
--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -19,6 +19,6 @@ COPY dev dev
 COPY tests tests
 COPY src src
 
-RUN pip3.11 install --upgrade pip && pip3.11 install .
+RUN pip3.11 install --upgrade pip && pip3.11 install . --ignore-installed
 
 CMD ["puptoo"]


### PR DESCRIPTION
- error: uninstall-no-record-file in image build

## Summary by Sourcery

Bug Fixes:
- Fix Docker image build failures by addressing the pip setuptools uninstall-no-record-file error in the upstream foreman Dockerfile.