### PR TITLE
feat: add ubi.repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ lib/*
 lib64
 .scannerwork
 .envs
-ubi.repo

--- a/ubi.repo
+++ b/ubi.repo
@@ -1,0 +1,62 @@
+[ubi-9-for-$basearch-baseos-rpms]
+name = Red Hat Universal Base Image 9 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-$basearch-baseos-debug-rpms]
+name = Red Hat Universal Base Image 9 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Universal Base Image 9 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-$basearch-appstream-rpms]
+name = Red Hat Universal Base Image 9 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-$basearch-appstream-debug-rpms]
+name = Red Hat Universal Base Image 9 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Universal Base Image 9 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-9-$basearch-rpms]
+name = Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-9-$basearch-debug-rpms]
+name = Red Hat Universal Base Image 9 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-9-$basearch-source-rpms]
+name = Red Hat Universal Base Image 9 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1


### PR DESCRIPTION
to enable mintmaker/renovate updates for rpms.lock.yaml

## Summary by Sourcery

Add configuration for a UBI repository to support rpm lockfile updates and adjust ignored files accordingly.

New Features:
- Introduce a ubi.repo configuration file for managing UBI RPM repositories.

Enhancements:
- Update .gitignore entries related to repository or lockfile artifacts.