### PR TITLE
(RHINENG-15959): Remove legacy workload fields in favor of profile["workloads"]

### DIFF
--- a/tests/test_ansible_info.py
+++ b/tests/test_ansible_info.py
@@ -14,9 +14,6 @@ automation-controller-1.0.1-1.x86_64   Wed 09 Nov 2016 14:52:01 AEDT   144619335
 def test_ansible_info():
     input_data = InputData().add(Specs.installed_rpms, RPMS)
     result = run_test(system_profile, input_data)
-    assert result["ansible"]["hub_version"] == "1.0.3"
-    assert result["ansible"]["catalog_worker_version"] == "1.0.2"
-    assert result["ansible"]["controller_version"] == "1.0.0"
     assert result["workloads"]["ansible"] == {
         "hub_version": "1.0.3",
         "catalog_worker_version": "1.0.2",

--- a/tests/test_crowdstrike.py
+++ b/tests/test_crowdstrike.py
@@ -24,7 +24,7 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_backend, FALCONCTL_BACKEND)
     input_data.add(Specs.falconctl_version, FALCONCTL_VERSION)
     result = run_test(system_profile, input_data)
-    assert result["third_party_services"]["crowdstrike"] == {
+    assert result["workloads"]["crowdstrike"] == {
         "falcon_aid": "44e3b7d20b434a2bb2815d9808fa3a8b",
         "falcon_backend": "kernel",
         "falcon_version": "7.14.16703.0",
@@ -41,7 +41,7 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_aid, FALCONCTL_AID)
     input_data.add(Specs.falconctl_backend, FALCONCTL_BACKEND)
     result = run_test(system_profile, input_data)
-    assert result["third_party_services"]["crowdstrike"] == {
+    assert result["workloads"]["crowdstrike"] == {
         "falcon_aid": "44e3b7d20b434a2bb2815d9808fa3a8b",
         "falcon_backend": "kernel",
     }
@@ -55,7 +55,7 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_backend, FALCONCTL_BACKEND)
     input_data.add(Specs.falconctl_version, "")
     result = run_test(system_profile, input_data)
-    assert result["third_party_services"]["crowdstrike"] == {
+    assert result["workloads"]["crowdstrike"] == {
         "falcon_aid": "44e3b7d20b434a2bb2815d9808fa3a8b",
         "falcon_backend": "kernel",
     }
@@ -71,7 +71,7 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_backend, "")
     input_data.add(Specs.falconctl_version, "")
     result = run_test(system_profile, input_data)
-    assert result["third_party_services"]["crowdstrike"] == {
+    assert result["workloads"]["crowdstrike"] == {
         "falcon_aid": "44e3b7d20b434a2bb2815d9808fa3a8b",
     }
     assert result["workloads"]["crowdstrike"] == {
@@ -82,7 +82,7 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_aid, "")
     input_data.add(Specs.falconctl_backend, FALCONCTL_BACKEND)
     result = run_test(system_profile, input_data)
-    assert result["third_party_services"]["crowdstrike"] == {
+    assert result["workloads"]["crowdstrike"] == {
         "falcon_backend": "kernel",
     }
     assert result["workloads"]["crowdstrike"] == {
@@ -93,7 +93,7 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_aid, "")
     input_data.add(Specs.falconctl_backend, FALCONCTL_BACKEND)
     result = run_test(system_profile, input_data)
-    assert result["third_party_services"]["crowdstrike"] == {
+    assert result["workloads"]["crowdstrike"] == {
         "falcon_backend": "kernel",
     }
     assert result["workloads"]["crowdstrike"] == {
@@ -105,7 +105,7 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_backend, "")
     input_data.add(Specs.falconctl_version, FALCONCTL_VERSION)
     result = run_test(system_profile, input_data)
-    assert result["third_party_services"]["crowdstrike"] == {
+    assert result["workloads"]["crowdstrike"] == {
         "falcon_version": "7.14.16703.0",
     }
     assert result["workloads"]["crowdstrike"] == {
@@ -118,12 +118,10 @@ def test_crowdstrike():
     input_data.add(Specs.falconctl_backend, "")
     input_data.add(Specs.falconctl_version, "")
     result = run_test(system_profile, input_data)
-    assert "third_party_services" not in result
     assert "workloads" not in result
 
     input_data = InputData()
     input_data.add(Specs.falconctl_aid, "")
     input_data.add(Specs.falconctl_backend, "")
     result = run_test(system_profile, input_data)
-    assert "third_party_services" not in result
     assert "workloads" not in result

--- a/tests/test_intersystems.py
+++ b/tests/test_intersystems.py
@@ -71,13 +71,6 @@ def test_intersystems():
     input_data.add(Specs.iris_cpf, IRIS_CPF_2, path="/intersystems2/iris.cpf")
     input_data.add(Specs.iris_cpf, IRIS_CPF_2, path="/intersystems3/iris.cpf")
     result = run_test(system_profile, input_data)
-    assert result["intersystems"]["is_intersystems"] is True
-    assert len(result["intersystems"]["running_instances"]) == 2
-    assert result["intersystems"]["running_instances"][0]["instance_name"] == "IRIS1"
-    assert result["intersystems"]["running_instances"][0]["product"] == "IRIS"
-    assert result["intersystems"]["running_instances"][0]["version"] == "2023.1"
-    assert result["intersystems"]["running_instances"][1]["instance_name"] == "IRIS2"
-    assert result["intersystems"]["running_instances"][1]["version"] == "2023.2"
     assert result["workloads"]["intersystems"] == {
         "is_intersystems": True,
         "running_instances": [
@@ -99,9 +92,7 @@ def test_intersystems():
     input_data.add(Specs.iris_list, IRIS_LIST)
     input_data.add(Specs.iris_cpf, IRIS_CPF_2, path="/intersystems3/iris.cpf")
     result = run_test(system_profile, input_data)
-    assert result["intersystems"]["is_intersystems"] is True
-    assert "running_instances" not in result["intersystems"]
-    result["workloads"]["intersystems"] = {
+    assert result["workloads"]["intersystems"] == {
         "is_intersystems": True
     }
 
@@ -110,9 +101,7 @@ def test_intersystems():
     input_data.add(Specs.iris_list, IRIS_LIST)
     input_data.add(Specs.iris_cpf, IRIS_CPF_3, path="/intersystems2/iris.cpf")
     result = run_test(system_profile, input_data)
-    assert result["intersystems"]["is_intersystems"] is True
-    assert "running_instances" not in result["intersystems"]
-    result["workloads"]["intersystems"] = {
+    assert result["workloads"]["intersystems"] == {
         "is_intersystems": True
     }
 
@@ -121,5 +110,4 @@ def test_intersystems():
     input_data.add(Specs.iris_list, "")
     input_data.add(Specs.iris_cpf, "", path="/intersystems1/iris.cpf")
     result = run_test(system_profile, input_data)
-    assert "intersystems" not in result
     assert "workloads" not in result

--- a/tests/test_mssql_info.py
+++ b/tests/test_mssql_info.py
@@ -11,5 +11,4 @@ mssql-server-1.0.4-1.x86_64  Tue 14 Jul 2015 09:25:38 AEST   1398536494
 def test_mssql_info():
     input_data = InputData().add(Specs.installed_rpms, RPMS)
     result = run_test(system_profile, input_data)
-    assert result["mssql"]["version"] == "1.0.4"
     assert result["workloads"]["mssql"] == {"version": "1.0.4"}

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -109,10 +109,6 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'instance_number': '88', 'sap_system': True, 'sids': ['D89', 'D90']}
-    assert result["sap_system"] == True
-    assert result["sap_instance_number"] == '88'
-    assert result["sap_sids"] == ['D89', 'D90']
-    assert result["sap"] == expected_sap_object
     assert result["workloads"]["sap"] == expected_sap_object
 
 
@@ -122,10 +118,6 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'instance_number': '90', 'sap_system': True, 'sids': ['D90']}
-    assert result["sap_system"] == True
-    assert result.get("sap_instance_number") == '90'
-    assert result.get("sap_sids") == ['D90']
-    assert result["sap"] == expected_sap_object
     assert result["workloads"]["sap"] == expected_sap_object
 
 
@@ -135,10 +127,6 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'sap_system': False}
-    assert result["sap_system"] == False
-    assert result.get("sap_instance_number") == None
-    assert result.get("sap_sids") == None
-    assert result["sap"] == expected_sap_object
     assert result["workloads"]["sap"] == expected_sap_object
 
 
@@ -148,8 +136,4 @@ def test_sap():
     result = run_test(system_profile, input_data)
 
     expected_sap_object = {'instance_number': '12', 'sap_system': True, 'sids': ['R4D', 'WDX']}
-    assert result["sap_system"] == True
-    assert result["sap_instance_number"] == '12'
-    assert result["sap_sids"] == ['R4D', 'WDX']
-    assert result["sap"] == expected_sap_object
     assert result["workloads"]["sap"] == expected_sap_object


### PR DESCRIPTION
Now that HBI ignores the legacy fields coming from the reporters, in favor of the workloads object. We can safely proceed to populate them from Puptoo.

See https://github.com/RedHatInsights/insights-host-inventory/pull/3108 

This commit removes the duplication of workload data between legacy root-level fields and the profile["workloads"] object. Previously, workload information was stored in both locations (e.g., profile["ansible"] and profile["workloads"]["ansible"]), which created unnecessary redundancy.

Changes:
- Ansible: Write directly to profile["workloads"]["ansible"] instead of profile["ansible"]
- SAP: Write directly to profile["workloads"]["sap"] instead of profile["sap"], profile["sap_system"], profile["sap_sids"], and profile["sap_instance_number"]
- MSSQL: Write directly to profile["workloads"]["mssql"] instead of profile["mssql"]
- InterSystems: Write directly to profile["workloads"]["intersystems"] instead of profile["intersystems"]
- CrowdStrike: Write directly to profile["workloads"]["crowdstrike"] instead of profile["third_party_services"]["crowdstrike"]
- Remove the legacy workloads.update() section that was copying data from legacy fields to workloads

All tests have been updated to assert only on profile["workloads"][*] fields, removing assertions on the now-removed legacy fields.

This simplifies the codebase and ensures workload data is stored in a single, consistent location.

## Summary by Sourcery

Consolidate all workload-related system profile data into the unified profile["workloads"] structure and drop legacy root-level workload fields.

Enhancements:
- Store Ansible, SAP, MSSQL, InterSystems, and CrowdStrike workload metadata exclusively under profile["workloads"] instead of legacy root-level or third_party_services fields.
- Ensure SAP version and related attributes are derived once and attached directly to the sap workload entry, and clean up empty workload sections from the profile.

Tests:
- Update Ansible, SAP, MSSQL, InterSystems, and CrowdStrike tests to assert only against profile["workloads"] fields and remove expectations for legacy workload locations.