### PR TITLE
fix: deduplicate items in sp "installed_products"

### DIFF
--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -674,9 +674,10 @@ def system_profile(
         installed_products = {}
         try:
             for product in product_ids.product_certs:
-                if product.get("id") and product["id"] not in installed_products:
+                product_id = product.get("id")
+                if product_id and product_id not in installed_products:
                     installed_products[product["id"]] = _remove_empties({
-                        "id": product["id"],
+                        "id": product_id,
                         "name": product.get("name"),
                     })
             profile["installed_products"] = sorted(

--- a/tests/test_installed_products.py
+++ b/tests/test_installed_products.py
@@ -72,6 +72,18 @@ id: 69
 Name: Red Hat Enterprise Linux Server
 """.strip()
 
+# Corner case to test the code, should not exist in real life
+INSTALLED_PRODUCTS_5 = """
+Product Certificate
+path: /etc/pki/product-default/69.pem
+id: 69
+Name: Red Hat Enterprise Linux Server
+Product Certificate
+path: /etc/pki/product/69.pem
+id: 69
+Name: Red Hat Enterprise Linux Server (a diff name)
+""".strip()
+
 
 def test_installed_products():
 
@@ -97,6 +109,13 @@ def test_installed_products():
 
     input_data = InputData()
     input_data.add(Specs.subscription_manager_installed_product_ids, INSTALLED_PRODUCTS_4)
+    result = run_test(system_profile, input_data)
+    assert result["installed_products"] == [
+            {"id": "69", "name": "Red Hat Enterprise Linux Server"},
+        ]
+
+    input_data = InputData()
+    input_data.add(Specs.subscription_manager_installed_product_ids, INSTALLED_PRODUCTS_5)
     result = run_test(system_profile, input_data)
     assert result["installed_products"] == [
             {"id": "69", "name": "Red Hat Enterprise Linux Server"},


### PR DESCRIPTION
## Summary by Sourcery

Deduplicate installed products in the generated system profile and extend tests to cover duplicate product certificate scenarios.

Bug Fixes:
- Avoid listing the same installed product multiple times in the system profile when duplicate product certificates share the same ID.

Tests:
- Add a test case ensuring duplicate product certificate entries result in a single installed product in the profile output.