### PR TITLE
build(iop): add cpe and correct name labels

### DIFF
--- a/.tekton/iop-puptoo-sat-6-18-pull-request.yaml
+++ b/.tekton/iop-puptoo-sat-6-18-pull-request.yaml
@@ -43,9 +43,10 @@ spec:
   - name: labels
     value:
       - 'url="https://www.redhat.com"'
-      - 'name="iop-puptoo"'
+      - 'name=satellite/iop-puptoo-rhel9'
       - 'description="This adds the satellite/iop-puptoo-rhel9 image to the Red Hat container registry. To pull this container image, run the following command: podman pull registry.redhat.io/satellite/iop-puptoo-rhel9"'
       - 'summary="A new satellite/iop-puptoo-rhel9 container image is now generally available in the Red Hat container registry."'
+      - 'cpe=cpe:/a:redhat:satellite:6.18::el9'
       - 'com.redhat.component="iop-puptoo"'
       - 'io.k8s.display-name="IoP Puptoo"'
       - 'io.k8s.description="This adds the satellite/iop-puptoo-rhel9 image to the Red Hat container registry. To pull this container image, run the following command: podman pull registry.redhat.io/satellite/iop-puptoo-rhel9"'

--- a/.tekton/iop-puptoo-sat-6-18-push.yaml
+++ b/.tekton/iop-puptoo-sat-6-18-push.yaml
@@ -40,9 +40,10 @@ spec:
   - name: labels
     value:
       - 'url="https://www.redhat.com"'
-      - 'name="iop-puptoo"'
+      - 'name=satellite/iop-puptoo-rhel9'
       - 'description="This adds the satellite/iop-puptoo-rhel9 image to the Red Hat container registry. To pull this container image, run the following command: podman pull registry.redhat.io/satellite/iop-puptoo-rhel9"'
       - 'summary="A new satellite/iop-puptoo-rhel9 container image is now generally available in the Red Hat container registry."'
+      - 'cpe=cpe:/a:redhat:satellite:6.18::el9'
       - 'com.redhat.component="iop-puptoo"'
       - 'io.k8s.display-name="IoP Puptoo"'
       - 'io.k8s.description="This adds the satellite/iop-puptoo-rhel9 image to the Red Hat container registry. To pull this container image, run the following command: podman pull registry.redhat.io/satellite/iop-puptoo-rhel9"'


### PR DESCRIPTION
Associated Jira ticket: [RHINENG-23160](https://issues.redhat.com/browse/RHINENG-23160)

Adds required cpe label and corrects name label for IoP builds.

## Summary by Sourcery

Update IoP Satellite 6.18 Tekton pipeline image metadata labels.

Build:
- Adjust container image name label to use satellite/iop-puptoo-rhel9 in IoP Satellite 6.18 PR and push pipelines.
- Add the required CPE label for the Satellite 6.18 RHEL 9 image in the IoP Tekton pipeline configs.