### PR TITLE
chore(deps): make the konflux build image respect wheel>=0.46.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -880,7 +880,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -1502,7 +1502,7 @@ version = "0.46.3"
 description = "Command line tool for manipulating wheel files"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d"},
     {file = "wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803"},
@@ -1517,4 +1517,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=77)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.11"
-content-hash = "e82fb604ed1f8fa2cd9c3968c8a5e2c11abe81de1c731dc209081d76e21d97ba"
+content-hash = "50c3f12789a8611782c4adf2081fca4ac835ba71fc48854ae26b947c204fb096"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ minio = "^7.2.15"
 urllib3 = "^2.5.0"
 setuptools = "^80.0.0"
 cachecontrol = "<0.14.4"
+wheel = ">=0.46.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
 flake8 = "^7.1.2"
 freezegun = "^1.5.1"
 jsonschema = "^4.23.0"
-wheel = ">=0.46.2"
 
 [tool.poetry.scripts]
 puptoo = 'src.puptoo.app:main'

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -170,9 +170,9 @@ hatchling==1.28.0 \
     #   redis
     #   urllib3
     #   watchtower
-packaging==26.0 \
-    --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 \
-    --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
+packaging==25.0 ; python_version == "3.11" \
+    --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
+    --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
     # via
     #   hatchling
     #   setuptools-scm
@@ -219,7 +219,7 @@ typing-extensions==4.15.0 ; python_version == "3.11" \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via setuptools-scm
-wheel==0.46.3 \
+wheel==0.46.3 ; python_version == "3.11" \
     --hash=sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d \
     --hash=sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -168,6 +168,3 @@ six==1.17.0 ; python_version == "3.11" \
 typing-extensions==4.15.0 ; python_version == "3.11" \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-wheel==0.46.3 ; python_version == "3.11" \
-    --hash=sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d \
-    --hash=sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803

--- a/requirements.txt
+++ b/requirements.txt
@@ -460,6 +460,9 @@ msgpack==1.1.2 ; python_version == "3.11" \
     --hash=sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20 \
     --hash=sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e \
     --hash=sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162
+packaging==25.0 ; python_version == "3.11" \
+    --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
+    --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
 prometheus-client==0.21.1 ; python_version == "3.11" \
     --hash=sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb \
     --hash=sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301
@@ -660,3 +663,6 @@ urllib3==2.6.3 ; python_version == "3.11" \
 watchtower==3.4.0 ; python_version == "3.11" \
     --hash=sha256:5eac65cbf2a7350bb43c3518485230a6135ed7dec7ccb88468828d68ab9fea26 \
     --hash=sha256:7d3c116aff72a73ce8f6fc0addd1d0daa04d3f9d53d87cedca3a5a65a264bf7d
+wheel==0.46.3 ; python_version == "3.11" \
+    --hash=sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d \
+    --hash=sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803


### PR DESCRIPTION
The wheel package version 0.46.3 lock in poetry.lock and requirements
  files are not respected in the konflux image build, meanwhile, it
  taking effects in jenkins built image. Moving the dep adding of wheel
  from dev to main dep group in pyproject.toml to archive this.

RHINENG-23881

## Summary by Sourcery

Align dependency specification so Konflux build images respect the pinned wheel version across environments.

Bug Fixes:
- Ensure Konflux build uses the pinned wheel>=0.46.2/0.46.3 version by promoting it from a dev dependency to a main dependency and reflecting it in requirements.txt.

Enhancements:
- Add explicit packaging dependency to requirements.txt for Python 3.11 builds.

Build:
- Update runtime and build requirements to include explicit packaging and wheel pins for consistent image builds across CI systems.