### PR TITLE
fix(security): remediate RPM CVEs from RHINENG-24672

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN ./configure --prefix=/usr && \
     make && \
     make install
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1770267347
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
 
 WORKDIR /app-root/
 

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -67,13 +67,13 @@ arches:
     name: glibc-headers
     evr: 2.34-231.el9_7.10
     sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-611.36.1.el9_7.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-611.38.1.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 3019841
-    checksum: sha256:a8d6bc21a121506d3ab4557de140b256424fef20cb3e40fb411f21f55cee3544
+    size: 3021673
+    checksum: sha256:d29c0b46854ac992dc8af47bb2e197c78564cf342bfe89b5c657bbb594b1f4eb
     name: kernel-headers
-    evr: 5.14.0-611.36.1.el9_7
-    sourcerpm: kernel-5.14.0-611.36.1.el9_7.src.rpm
+    evr: 5.14.0-611.38.1.el9_7
+    sourcerpm: kernel-5.14.0-611.38.1.el9_7.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/keyutils-libs-devel-1.6.3-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 66082
@@ -641,27 +641,27 @@ arches:
     name: perl-vars
     evr: 1.05-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.11-3.11.13-5.el9_7.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.11-3.11.13-5.1.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 31725
-    checksum: sha256:74e19a0e3bd164337e6602c3bb95b5a7c803de9b8a4d5c3997096c1e7c2142a7
+    size: 31827
+    checksum: sha256:eb490f1bfc37ee9639e06641febd6d1a9035853a0e4037fe9272bd75f7675a2e
     name: python3.11
-    evr: 3.11.13-5.el9_7
-    sourcerpm: python3.11-3.11.13-5.el9_7.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.11-devel-3.11.13-5.el9_7.x86_64.rpm
+    evr: 3.11.13-5.1.el9_7
+    sourcerpm: python3.11-3.11.13-5.1.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.11-devel-3.11.13-5.1.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 290023
-    checksum: sha256:27e8eade4066fd353ddb41e266b7a3e032db906f31e1fb490bfe8dded78c1f5d
+    size: 290088
+    checksum: sha256:3380adcb021c7e872c05e4b4884baef4ced6d3cf03bbe50e0147de970aa3a4c3
     name: python3.11-devel
-    evr: 3.11.13-5.el9_7
-    sourcerpm: python3.11-3.11.13-5.el9_7.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.11-libs-3.11.13-5.el9_7.x86_64.rpm
+    evr: 3.11.13-5.1.el9_7
+    sourcerpm: python3.11-3.11.13-5.1.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.11-libs-3.11.13-5.1.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 10716237
-    checksum: sha256:8a305ebd12caa0c61b7ec0d9896f5bb6b0878ab3d363ea214c94fee74abb214c
+    size: 10715230
+    checksum: sha256:f2d5ac78c2553c34367933700053a7234584685a14940d81e19a9f9a6d724a37
     name: python3.11-libs
-    evr: 3.11.13-5.el9_7
-    sourcerpm: python3.11-3.11.13-5.el9_7.src.rpm
+    evr: 3.11.13-5.1.el9_7
+    sourcerpm: python3.11-3.11.13-5.1.el9_7.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.11-pip-22.3.1-6.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 3351885


### PR DESCRIPTION
## Changes Made
- Updated base image `ubi9/s2i-base` to `9.7-1773032613`
- Updated base image `ubi9/ubi-minimal` to `9.7-1773204619`
- Regenerated hermetic build lockfile (rpms.lock.yaml)

Fixes RHINENG-24672

## Summary by Sourcery

Update container base images and hermetic RPM lockfile to incorporate latest RHEL 9.7 security fixes.

Bug Fixes:
- Refresh glibc, kernel header, and Python 3.11 RPMs in the hermetic lockfile to remediate known CVEs in the build environment.

Enhancements:
- Bump UBI9 s2i-base and ubi-minimal base images to newer 9.7 builds for improved security posture.