### PR TITLE
RHINENG-25215: fix broken parsing on "systemd" sp field

### DIFF
--- a/dev/test-archives/core-base/data/insights_commands/systemctl_status_--all
+++ b/dev/test-archives/core-base/data/insights_commands/systemctl_status_--all
@@ -1,0 +1,8 @@
+    State: running
+     Jobs: 2 queued
+   Failed: 0 units
+               | |-360624 grep -F -- "Failed: \nJobs: \nState: "
+             |-360624 grep -F -- "Failed: \nJobs: \nState: "
+                 | |-360624 grep -F -- "Failed: \nJobs: \nState: "
+             | |-360624 grep -F -- "Failed: \nJobs: \nState: "
+               | |-360624 grep -F -- "Failed: \nJobs: \nState: "

--- a/dev/test-archives/core-base/meta_data/insights.specs.Specs.systemctl_status_all.json
+++ b/dev/test-archives/core-base/meta_data/insights.specs.Specs.systemctl_status_all.json
@@ -1,0 +1,1 @@
+{"name": "insights.specs.Specs.systemctl_status_all", "exec_time": 9.989738464355469e-05, "errors": [], "results": {"type": "insights.core.spec_factory.CommandOutputProvider", "object": {"rc": null, "cmd": "/bin/systemctl status --all", "args": null, "save_as": false, "relative_path": "insights_commands/systemctl_status_--all"}}, "ser_time": 0.4403553009033203}

--- a/src/puptoo/process/profile.py
+++ b/src/puptoo/process/profile.py
@@ -731,15 +731,20 @@ def system_profile(
         profile["is_runtimes"] = True
 
     if systemctl_status_all:
-        profile["systemd"] = {
-            "state": systemctl_status_all.state,
-            "jobs_queued": int(systemctl_status_all.jobs.split(" ")[0]),
-            "failed": int(systemctl_status_all.failed.split(" ")[0])
-        }
-        if list_units:
-            if int(systemctl_status_all.failed.split(" ")[0]) > 0:
-                profile["systemd"]["failed_services"] = [svc for svc in list_units.service_names
-                    if list_units.is_failed(svc)]
+        try:
+            profile["systemd"] = {
+                "state": systemctl_status_all.state,
+                "jobs_queued": int(systemctl_status_all.jobs.split(" ")[0]) if systemctl_status_all.jobs else None,
+                "failed": int(systemctl_status_all.failed.split(" ")[0]) if systemctl_status_all.failed else None
+            }
+            if list_units:
+                if profile["systemd"]["failed"] is not None and profile["systemd"]["failed"] > 0:
+                    profile["systemd"]["failed_services"] = [svc for svc in list_units.service_names
+                        if list_units.is_failed(svc)]
+            profile["systemd"] = _remove_empties(profile["systemd"])
+        except Exception as e:
+            # log the error and continue with the next parser
+            catch_error("systemctl_status_all", e)
 
     if aws_public_hostnames:
         profile["public_dns"] = _remove_empty_string(aws_public_hostnames)

--- a/tests/test_systemctl_status_all.py
+++ b/tests/test_systemctl_status_all.py
@@ -34,11 +34,40 @@ neutron-openvswitch-agent.service                                           load
 chronyd.service                                                             loaded failed failed    NTP client/server
 """.strip()
 
+SYSTEMCTLSTATUSALL_2 = """
+   Failed: 1 units
+               | |-9743 grep -F -- "Failed: "
+             |-9743 grep -F -- "Failed: "
+                 | |-9743 grep -F -- "Failed: "
+             | |-9743 grep -F -- "Failed: "
+               | |-9743 grep -F -- "Failed: "
+""".strip()
+
+SYSTEMCTLSTATUSALL_3 = """
+     Jobs: 0 queued
+   Failed: 1 units
+               | |-9743 grep -F -- "Failed: "
+             |-9743 grep -F -- "Failed: "
+                 | |-9743 grep -F -- "Failed: "
+             | |-9743 grep -F -- "Failed: "
+               | |-9743 grep -F -- "Failed: "
+""".strip()
+
+SYSTEMCTLSTATUSALL_4 = """
+     Jobs: 0 queued
+   Failed: units
+               | |-9743 grep -F -- "Failed: "
+             |-9743 grep -F -- "Failed: "
+                 | |-9743 grep -F -- "Failed: "
+             | |-9743 grep -F -- "Failed: "
+               | |-9743 grep -F -- "Failed: "
+""".strip()
+
 
 def test_systemctl_status():
     input_data = InputData().add(Specs.systemctl_status_all, SYSTEMCTLSTATUSALL)
     result = run_test(system_profile, input_data)
-    
+
     assert result['systemd']['failed'] == 2
     assert result['systemd']['jobs_queued'] == 0
     assert result['systemd']['state'] == 'degraded'
@@ -52,3 +81,35 @@ def test_systemctl_status():
     assert result['systemd']['jobs_queued'] == 0
     assert result['systemd']['state'] == 'degraded'
     assert result['systemd']['failed_services'] == ['chronyd.service']
+
+
+def test_systemctl_status_missing_state_and_jobs():
+    """Test with only Failed field present (missing State and Jobs)"""
+    input_data = InputData().add(Specs.systemctl_status_all, SYSTEMCTLSTATUSALL_2)
+    result = run_test(system_profile, input_data)
+
+    assert result['systemd']['failed'] == 1
+    assert 'jobs_queued' not in result['systemd']
+    assert 'state' not in result['systemd']
+
+
+def test_systemctl_status_missing_state():
+    """Test with Jobs and Failed present (missing State)"""
+    input_data = InputData().add(Specs.systemctl_status_all, SYSTEMCTLSTATUSALL_3)
+    input_data.add(Specs.systemctl_list_units, LISTUNITS)
+    result = run_test(system_profile, input_data)
+
+    assert result['systemd']['failed'] == 1
+    assert result['systemd']['jobs_queued'] == 0
+    assert 'state' not in result['systemd']
+    assert result['systemd']['failed_services'] == ['chronyd.service']
+
+
+def test_systemctl_status_invalid_failed_value():
+    """Test with invalid Failed value 'units' - should skip failed field"""
+    input_data = InputData().add(Specs.systemctl_status_all, SYSTEMCTLSTATUSALL_4)
+    input_data.add(Specs.systemctl_list_units, LISTUNITS)
+    result = run_test(system_profile, input_data)
+
+    assert 'systemd' not in result
+    assert result.get('systemd') == None


### PR DESCRIPTION
## Summary by Sourcery

Handle missing or invalid systemd status fields more robustly when building the system profile.

Bug Fixes:
- Avoid crashes when systemctl status output has missing Jobs or Failed fields or non-numeric Failed values, skipping invalid data instead.

Tests:
- Add test coverage for systemctl status parsing with missing Jobs and State fields and with invalid Failed values.