### PR TITLE
ci(update): Bump the Konflux pipelines (master)

### DIFF
--- a/.tekton/insights-puptoo-pull-request.yaml
+++ b/.tekton/insights-puptoo-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.64.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo

--- a/.tekton/insights-puptoo-push.yaml
+++ b/.tekton/insights-puptoo-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.64.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-puptoo


### PR DESCRIPTION
Bump the main konflux pipelines to [1.66](https://github.com/RedHatInsights/konflux-pipelines/tree/v1.66.0)

## Summary by Sourcery

CI:
- Bump Konflux Tekton pipeline reference from v1.64.0 to v1.66.0 for pull request and push pipelines.