### PR TITLE
chore(deps): bump urllib3 to 2.7.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1407,14 +1407,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ app-common-python = "0.2.8"
 watchtower = "^3.4.0"
 logstash_formatter = "^0.5.17"
 minio = "^7.2.15"
-urllib3 = "^2.5.0"
+urllib3 = ">=2.7.0"
 setuptools = "^80.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -649,9 +649,9 @@ tomli==2.3.0 ; python_version == "3.11" \
 typing-extensions==4.15.0 ; python_version == "3.11" \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-urllib3==2.6.2 ; python_version == "3.11" \
-    --hash=sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797 \
-    --hash=sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd
+urllib3==2.7.0 ; python_version == "3.11" \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
 watchtower==3.4.0 ; python_version == "3.11" \
     --hash=sha256:5eac65cbf2a7350bb43c3518485230a6135ed7dec7ccb88468828d68ab9fea26 \
     --hash=sha256:7d3c116aff72a73ce8f6fc0addd1d0daa04d3f9d53d87cedca3a5a65a264bf7d


### PR DESCRIPTION
# Jira

[SAT-45605](https://redhat.atlassian.net/browse/SAT-45605)
[SAT-45606](https://redhat.atlassian.net/browse/SAT-45606)

[SAT-45605]: https://redhat.atlassian.net/browse/SAT-45605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAT-45606]: https://redhat.atlassian.net/browse/SAT-45606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Build:
- Align runtime dependency constraints to require urllib3 >=2.7.0 in pyproject.toml and requirements.txt.