### PR TITLE
Fixing the CVE - urllib3: Decompression-bomb safeguards bypassed in parts of the streaming API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -626,7 +626,7 @@ six==1.17.0 ; python_version == "3.11" \
 typing-extensions==4.15.0 ; python_version == "3.11" \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-urllib3==2.6.3 ; python_version == "3.11" \
+urllib3==2.7.0 ; python_version == "3.11" \
     --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
     --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
 watchtower==3.4.0 ; python_version == "3.11" \


### PR DESCRIPTION
Fixed the CVE: urllib3: Decompression-bomb safeguards bypassed in parts of the streaming API

From 2.6.0 to  2.7.0