### PR TITLE
chore: Changed the version of urllib3 from 2.6.3 to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -626,9 +626,9 @@ six==1.17.0 ; python_version == "3.11" \
 typing-extensions==4.15.0 ; python_version == "3.11" \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-urllib3==2.6.3 ; python_version == "3.11" \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 ; python_version == "3.11" \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897 
 watchtower==3.4.0 ; python_version == "3.11" \
     --hash=sha256:5eac65cbf2a7350bb43c3518485230a6135ed7dec7ccb88468828d68ab9fea26 \
     --hash=sha256:7d3c116aff72a73ce8f6fc0addd1d0daa04d3f9d53d87cedca3a5a65a264bf7d


### PR DESCRIPTION
## Summary by Sourcery

Update HTTP client dependency and introduce Pipenv project configuration.

Enhancements:
- Bump urllib3 dependency from 2.6.3 to 2.7.0 for Python 3.11 environments.
- Add Pipfile and lockfile to define and lock Python 3.11 application dependencies under Pipenv.