### PR TITLE
chore(deps): update dependency for idna to 3.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -304,9 +304,9 @@ defusedxml==0.7.1 ; python_version == "3.11" \
 filelock==3.29.0; python_version == "3.11" \
     --hash=sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90 \
     --hash=sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258
-idna==3.13; python_version == "3.11" \
-    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
-    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
+idna==3.15; python_version == "3.11" \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
 insights-core==3.7.6; python_version == "3.11" \
     --hash=sha256:275a817d1f8a88363a37bcc57c48c90e1873d1ea2baf59140050140051e5be74 \
     --hash=sha256:90d33972a99e2c3b5c49778bb0fe9643227dff5b038dc06e8878d49c58326d79


### PR DESCRIPTION
I updated idna in requirements.txt for dependabot security issue below

Internationalized Domain Names in Applications (IDNA): Specially crafted inputs to idna.encode() can bypass CVE-2024-3651 