### PR TITLE
refactor: replace inline service routing with handler registry pattern

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -1,20 +1,15 @@
 import json
 import os
 import signal
-import re
-from datetime import datetime, timedelta
 from functools import partial
 from time import time
-from base64 import b64decode
 
 from confluent_kafka import KafkaError
 from prometheus_client import Info, Summary, start_http_server
-from .upload import upload_object
 
-from .process import extract
-from .process.profile import MAC_REGEX
-from .mq import consume, msgs, produce
-from .utils import config, metrics, puptoo_logging, validators
+from .handlers import get_handler
+from .mq import consume, produce
+from .utils import config, metrics, puptoo_logging
 from .utils.puptoo_logging import threadctx
 from redis import Redis
 
@@ -42,28 +37,6 @@ def get_extra(account="unknown", org_id="unknown", request_id="unknown"):
     threadctx.account = account
     threadctx.org_id = org_id
     return {"account": account, "org_id": org_id, "request_id": request_id}
-
-
-def get_staletime():
-    the_time = datetime.now() + timedelta(hours=29)
-    return the_time.astimezone().isoformat()
-
-
-def get_owner(ident):
-    s = b64decode(ident).decode("utf-8")
-    identity = json.loads(s)
-    if identity["identity"].get("system"):
-        owner_id = identity["identity"]["system"].get("cn")
-        return owner_id
-
-
-def clean_macs(facts):
-    if facts["metadata"].get("mac_addresses"):
-        m = re.compile(MAC_REGEX)
-        facts["metadata"]["mac_addresses"] = [
-            mac for mac in facts["metadata"]["mac_addresses"] if m.match(mac)
-        ]
-    return facts
 
 
 producer = None
@@ -147,13 +120,14 @@ def main():
                 service = dict(msg.headers() or []).get("service")
                 if service:
                     service = service.decode("utf-8")
-                    if service in ["advisor", "compliance", "malware-detection"]:
+                    handler = get_handler(service)
+                    if handler:
                         msg = json.loads(msg.value().decode("utf-8"))
                         extra = get_extra(
                             msg.get("account"), msg.get("org_id"), msg.get("request_id")
                         )
                         handle_retries(redis, extra["request_id"])
-                        handle_message(msg, service, extra)
+                        handler.handle(msg, service, extra, send_message=send_message)
             except Exception:
                 consumer.commit()
                 logger.exception("An error occurred during message processing")
@@ -166,22 +140,6 @@ def main():
         producer.flush()
     except Exception:
         logger.exception("Puptoo failed with Error")
-
-
-def process_archive(msg, extra):
-    metrics.extraction_count.inc()
-    facts = extract(msg, extra)
-    if facts.get("error"):
-        metrics.extract_failure.inc()
-        raise Exception("process_archive failure", facts.get("error"))
-    logger.debug(
-        "extracted facts from message for %s\nMessage: %s\nFacts: %s",
-        extra["request_id"],
-        msg,
-        facts,
-    )
-    metrics.extract_success.inc()
-    return facts
 
 
 def delivery_report(err, msg=None, extra=None):
@@ -226,109 +184,6 @@ def send_message(topic, msg, extra):
         metrics.msg_send_failure.labels(topic).inc()
         logger.exception(
             "Failed to produce message to [%s] topic: %s", topic, extra["request_id"]
-        )
-
-
-def handle_message(msg, service, extra):
-    msg["elapsed_time"] = time()
-    logger.info("received request_id: %s", extra["request_id"])
-    send_message(
-        config.TRACKER_TOPIC,
-        msgs.tracker_message(extra, "received", "Received message"),
-        extra,
-    )
-    metrics.msg_processed_count.labels(service).inc()
-
-    try:
-        # Facts extraction
-        facts = {}
-        if service == "advisor":
-            facts = process_archive(msg, extra)
-        elif service in ["compliance", "malware-detection"]:
-            facts = msg.get("metadata")
-        else:
-            raise Exception("Unsupported service type.")
-
-        # Facts validation
-        if not facts:
-            raise Exception("Empty facts extracted.")
-        if not validators.validateCanonicalFacts(facts):
-            raise Exception("Missing canonical fact(s).")
-
-        # Facts refinement
-        yum_updates = None
-        facts["stale_timestamp"] = get_staletime()
-        facts["reporter"] = "puptoo"
-        if facts.get("metadata"):
-            clean_macs(facts)
-        if facts.get("system_profile"):
-            owner_id = get_owner(msg["b64_identity"])
-            if owner_id:
-                facts["system_profile"]["owner_id"] = owner_id
-            if facts["system_profile"].get("is_ros"):
-                msg["is_ros"] = True
-            if facts["system_profile"].get("is_ros_v2"):
-                msg["is_ros_v2"] = True
-            if facts["system_profile"].get("is_pcp_raw_data_collected"):
-                msg["is_pcp_raw_data_collected"] = True
-            if facts["system_profile"].get("is_runtimes"):
-                msg["is_runtimes"] = True
-            if facts["system_profile"].get("yum_updates"):
-                yum_updates = facts["system_profile"].get("yum_updates")
-                # delete yum_updates from system_profile as it is already present under custom_metadata
-                del facts["system_profile"]["yum_updates"]
-
-        # Override archive hostname with name provided by client metadata
-        if msg["metadata"].get("display_name"):
-            facts["display_name"] = msg["metadata"]["display_name"]
-        if msg["metadata"].get("ansible_host"):
-            facts["ansible_host"] = msg["metadata"]["ansible_host"]
-
-        # Upload yum_updates to s3
-        if yum_updates and not config.DISABLE_S3_UPLOAD:
-            try:
-                upload_object(yum_updates, extra, msg)
-            except:
-                logger.exception("Error occurred while uploading object.")
-
-    except Exception as e:
-        metrics.msg_processed_failure.labels(service).inc()
-        logger.exception(
-            "Failed to process message of %s service: %s: %s",
-            service,
-            extra["request_id"],
-            str(e),
-        )
-        send_message(
-            config.TRACKER_TOPIC,
-            msgs.tracker_message(
-                extra,
-                "error",
-                "Unable to extract facts of %s service: %s" % (service, str(e)),
-            ),
-            extra,
-        )
-        send_message(
-            config.VALIDATION_TOPIC,
-            msgs.validation_message(msg, facts, "failure"),
-            extra,
-        )
-        send_message(
-            config.TRACKER_TOPIC,
-            msgs.tracker_message(
-                extra, "failed", "Validation failure. Message sent to storage broker"
-            ),
-            extra,
-        )
-    else:
-        metrics.msg_processed_success.labels(service).inc()
-        send_message(
-            config.INVENTORY_TOPIC, msgs.inv_message("add_host", facts, msg), extra
-        )
-        send_message(
-            config.TRACKER_TOPIC,
-            msgs.tracker_message(extra, "success", "Message sent to inventory"),
-            extra,
         )
 
 

--- a/src/puptoo/handlers/__init__.py
+++ b/src/puptoo/handlers/__init__.py
@@ -1,0 +1,27 @@
+from .base import BaseHandler
+
+_REGISTRY: dict[str, type[BaseHandler]] = {}
+
+
+def handler(service: str):
+    """Class decorator that registers a handler for a service type."""
+
+    def decorator(cls: type[BaseHandler]) -> type[BaseHandler]:
+        _REGISTRY[service] = cls
+        return cls
+
+    return decorator
+
+
+def register(service: str, handler_cls: type[BaseHandler]) -> None:
+    _REGISTRY[service] = handler_cls
+
+
+def get_handler(service: str) -> BaseHandler | None:
+    handler_cls = _REGISTRY.get(service)
+    if handler_cls is None:
+        return None
+    return handler_cls()
+
+
+from . import advisor, compliance  # noqa: E402, F401

--- a/src/puptoo/handlers/advisor.py
+++ b/src/puptoo/handlers/advisor.py
@@ -1,0 +1,30 @@
+import logging
+
+from . import handler
+from .base import BaseHandler
+from ..mq import msgs
+from ..process import extract
+from ..utils import metrics
+
+logger = logging.getLogger("puptoo")
+
+
+@handler("advisor")
+class AdvisorHandler(BaseHandler):
+    def process(self, msg: dict, extra: dict) -> dict:
+        metrics.extraction_count.inc()
+        facts = extract(msg, extra)
+        if facts.get("error"):
+            metrics.extract_failure.inc()
+            raise Exception("process_archive failure", facts.get("error"))
+        logger.debug(
+            "extracted facts from message for %s\nMessage: %s\nFacts: %s",
+            extra["request_id"],
+            msg,
+            facts,
+        )
+        metrics.extract_success.inc()
+        return facts
+
+    def build_hbi_messages(self, facts: dict, msg: dict) -> list[dict]:
+        return [msgs.inv_message("add_host", facts, msg)]

--- a/src/puptoo/handlers/base.py
+++ b/src/puptoo/handlers/base.py
@@ -1,0 +1,138 @@
+import json
+import logging
+import re
+from abc import ABC, abstractmethod
+from base64 import b64decode
+from datetime import datetime, timedelta
+from time import time
+
+from ..mq import msgs
+from ..process.profile import MAC_REGEX
+from ..upload import upload_object
+from ..utils import config, metrics, validators
+
+logger = logging.getLogger("puptoo")
+
+
+def _get_staletime():
+    the_time = datetime.now() + timedelta(hours=29)
+    return the_time.astimezone().isoformat()
+
+
+def _get_owner(ident):
+    s = b64decode(ident).decode("utf-8")
+    identity = json.loads(s)
+    if identity["identity"].get("system"):
+        owner_id = identity["identity"]["system"].get("cn")
+        return owner_id
+
+
+def _clean_macs(facts):
+    if facts["metadata"].get("mac_addresses"):
+        m = re.compile(MAC_REGEX)
+        facts["metadata"]["mac_addresses"] = [
+            mac for mac in facts["metadata"]["mac_addresses"] if m.match(mac)
+        ]
+    return facts
+
+
+class BaseHandler(ABC):
+    @abstractmethod
+    def process(self, msg: dict, extra: dict) -> dict:
+        """Extract facts from the incoming message. Returns a facts dict."""
+
+    @abstractmethod
+    def build_hbi_messages(self, facts: dict, msg: dict) -> list[dict]:
+        """Build HBI message payload(s). Returns a list of dicts."""
+
+    def handle(self, msg, service, extra, *, send_message):
+        msg["elapsed_time"] = time()
+        logger.info("received request_id: %s", extra["request_id"])
+        send_message(
+            config.TRACKER_TOPIC,
+            msgs.tracker_message(extra, "received", "Received message"),
+            extra,
+        )
+        metrics.msg_processed_count.labels(service).inc()
+
+        facts = {}
+        try:
+            facts = self.process(msg, extra)
+
+            if not facts:
+                raise Exception("Empty facts extracted.")
+            if not validators.validateCanonicalFacts(facts):
+                raise Exception("Missing canonical fact(s).")
+
+            yum_updates = None
+            facts["stale_timestamp"] = _get_staletime()
+            facts["reporter"] = "puptoo"
+            if facts.get("metadata"):
+                _clean_macs(facts)
+            if facts.get("system_profile"):
+                owner_id = _get_owner(msg["b64_identity"])
+                if owner_id:
+                    facts["system_profile"]["owner_id"] = owner_id
+                if facts["system_profile"].get("is_ros"):
+                    msg["is_ros"] = True
+                if facts["system_profile"].get("is_ros_v2"):
+                    msg["is_ros_v2"] = True
+                if facts["system_profile"].get("is_pcp_raw_data_collected"):
+                    msg["is_pcp_raw_data_collected"] = True
+                if facts["system_profile"].get("is_runtimes"):
+                    msg["is_runtimes"] = True
+                if facts["system_profile"].get("yum_updates"):
+                    yum_updates = facts["system_profile"].get("yum_updates")
+                    del facts["system_profile"]["yum_updates"]
+
+            if msg["metadata"].get("display_name"):
+                facts["display_name"] = msg["metadata"]["display_name"]
+            if msg["metadata"].get("ansible_host"):
+                facts["ansible_host"] = msg["metadata"]["ansible_host"]
+
+            if yum_updates and not config.DISABLE_S3_UPLOAD:
+                try:
+                    upload_object(yum_updates, extra, msg)
+                except:
+                    logger.exception("Error occurred while uploading object.")
+
+        except Exception as e:
+            metrics.msg_processed_failure.labels(service).inc()
+            logger.exception(
+                "Failed to process message of %s service: %s: %s",
+                service,
+                extra["request_id"],
+                str(e),
+            )
+            send_message(
+                config.TRACKER_TOPIC,
+                msgs.tracker_message(
+                    extra,
+                    "error",
+                    "Unable to extract facts of %s service: %s" % (service, str(e)),
+                ),
+                extra,
+            )
+            send_message(
+                config.VALIDATION_TOPIC,
+                msgs.validation_message(msg, facts, "failure"),
+                extra,
+            )
+            send_message(
+                config.TRACKER_TOPIC,
+                msgs.tracker_message(
+                    extra,
+                    "failed",
+                    "Validation failure. Message sent to storage broker",
+                ),
+                extra,
+            )
+        else:
+            metrics.msg_processed_success.labels(service).inc()
+            for hbi_msg in self.build_hbi_messages(facts, msg):
+                send_message(config.INVENTORY_TOPIC, hbi_msg, extra)
+            send_message(
+                config.TRACKER_TOPIC,
+                msgs.tracker_message(extra, "success", "Message sent to inventory"),
+                extra,
+            )

--- a/src/puptoo/handlers/compliance.py
+++ b/src/puptoo/handlers/compliance.py
@@ -1,0 +1,17 @@
+from . import handler
+from .base import BaseHandler
+from ..mq import msgs
+
+
+@handler("compliance")
+class ComplianceHandler(BaseHandler):
+    def process(self, msg: dict, extra: dict) -> dict:
+        return msg.get("metadata") or {}
+
+    def build_hbi_messages(self, facts: dict, msg: dict) -> list[dict]:
+        return [msgs.inv_message("add_host", facts, msg)]
+
+
+@handler("malware-detection")
+class MalwareDetectionHandler(ComplianceHandler):
+    pass

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 from src.puptoo import app
+from src.puptoo.handlers.base import _get_staletime
 from freezegun import freeze_time
 from datetime import datetime
 
@@ -6,7 +7,7 @@ from datetime import datetime
 @freeze_time("2019-7-23")
 def test_get_staletime():
     dtz = datetime.fromtimestamp(1563944400).astimezone()
-    assert app.get_staletime() == dtz.isoformat()
+    assert _get_staletime() == dtz.isoformat()
 
 
 def test_get_extra():

--- a/tests/test_clean_macs.py
+++ b/tests/test_clean_macs.py
@@ -1,4 +1,4 @@
-from src.puptoo.app import clean_macs
+from src.puptoo.handlers.base import _clean_macs as clean_macs
 
 
 GOOD_MACS = {"metadata": {"mac_addresses": ["52:54:00:fd:be:d0", "b4:6b:fc:9e:ae:0d"]}}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,250 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.puptoo.handlers import get_handler, handler, register, _REGISTRY
+from src.puptoo.handlers.base import BaseHandler
+
+
+class DummyHandler(BaseHandler):
+    def process(self, msg: dict, extra: dict) -> dict:
+        return {"dummy": True}
+
+    def build_hbi_messages(self, facts: dict, msg: dict) -> list[dict]:
+        return [{"operation": "add_host", "data": facts}]
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    saved = dict(_REGISTRY)
+    _REGISTRY.clear()
+    yield
+    _REGISTRY.clear()
+    _REGISTRY.update(saved)
+
+
+# --- Registry basics ---
+
+
+def test_get_handler_returns_none_for_unknown():
+    assert get_handler("unknown") is None
+
+
+def test_get_handler_returns_none_when_empty():
+    assert get_handler("advisor") is None
+
+
+def test_register_and_get_handler():
+    register("test-service", DummyHandler)
+    h = get_handler("test-service")
+    assert h is not None
+    assert isinstance(h, DummyHandler)
+
+
+def test_get_handler_returns_new_instance_each_call():
+    register("test-service", DummyHandler)
+    h1 = get_handler("test-service")
+    h2 = get_handler("test-service")
+    assert h1 is not h2
+
+
+# --- @handler decorator ---
+
+
+def test_handler_decorator_registers():
+    @handler("my-service")
+    class MyHandler(BaseHandler):
+        def process(self, msg: dict, extra: dict) -> dict:
+            return {}
+
+        def build_hbi_messages(self, facts: dict, msg: dict) -> list[dict]:
+            return []
+
+    assert _REGISTRY["my-service"] is MyHandler
+    h = get_handler("my-service")
+    assert isinstance(h, MyHandler)
+
+
+def test_handler_decorator_returns_class_unchanged():
+    @handler("svc")
+    class H(BaseHandler):
+        def process(self, msg: dict, extra: dict) -> dict:
+            return {}
+
+        def build_hbi_messages(self, facts: dict, msg: dict) -> list[dict]:
+            return []
+
+    assert H.__name__ == "H"
+
+
+# --- Abstract interface ---
+
+
+def test_handler_process():
+    h = DummyHandler()
+    result = h.process({}, {})
+    assert result == {"dummy": True}
+
+
+def test_handler_build_hbi_messages():
+    h = DummyHandler()
+    facts = {"fqdn": "test.example.com"}
+    result = h.build_hbi_messages(facts, {})
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["data"] == facts
+
+
+def test_base_handler_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        BaseHandler()
+
+
+# --- Concrete handlers ---
+
+
+@pytest.fixture()
+def populated_registry():
+    from src.puptoo.handlers import advisor, compliance  # noqa: F401
+
+    register("advisor", advisor.AdvisorHandler)
+    register("compliance", compliance.ComplianceHandler)
+    register("malware-detection", compliance.MalwareDetectionHandler)
+
+
+def test_dispatch_advisor(populated_registry):
+    from src.puptoo.handlers.advisor import AdvisorHandler
+
+    h = get_handler("advisor")
+    assert isinstance(h, AdvisorHandler)
+
+
+def test_dispatch_compliance(populated_registry):
+    from src.puptoo.handlers.compliance import ComplianceHandler
+
+    h = get_handler("compliance")
+    assert isinstance(h, ComplianceHandler)
+
+
+def test_dispatch_malware_detection(populated_registry):
+    from src.puptoo.handlers.compliance import MalwareDetectionHandler
+
+    h = get_handler("malware-detection")
+    assert isinstance(h, MalwareDetectionHandler)
+
+
+def test_dispatch_qpc_returns_none(populated_registry):
+    assert get_handler("qpc") is None
+
+
+def test_dispatch_unknown_returns_none(populated_registry):
+    assert get_handler("unknown") is None
+
+
+def test_malware_detection_is_subclass_of_compliance():
+    from src.puptoo.handlers.compliance import (
+        ComplianceHandler,
+        MalwareDetectionHandler,
+    )
+
+    assert issubclass(MalwareDetectionHandler, ComplianceHandler)
+
+
+def test_compliance_handler_process_returns_metadata():
+    from src.puptoo.handlers.compliance import ComplianceHandler
+
+    h = ComplianceHandler()
+    msg = {"metadata": {"fqdn": "host.example.com"}}
+    result = h.process(msg, {})
+    assert result == {"fqdn": "host.example.com"}
+
+
+def test_compliance_handler_process_returns_empty_on_missing_metadata():
+    from src.puptoo.handlers.compliance import ComplianceHandler
+
+    h = ComplianceHandler()
+    result = h.process({}, {})
+    assert result == {}
+
+
+# --- Template method (handle) ---
+
+
+@patch("src.puptoo.handlers.base.upload_object")
+@patch("src.puptoo.handlers.base.msgs")
+@patch("src.puptoo.handlers.base.validators")
+@patch("src.puptoo.handlers.base.config")
+@patch("src.puptoo.handlers.base.metrics")
+def test_handle_success_path(
+    mock_metrics, mock_config, mock_validators, mock_msgs, mock_upload
+):
+    mock_validators.validateCanonicalFacts.return_value = True
+    mock_config.TRACKER_TOPIC = "tracker"
+    mock_config.INVENTORY_TOPIC = "inventory"
+    mock_config.DISABLE_S3_UPLOAD = True
+
+    send = MagicMock()
+    h = DummyHandler()
+    msg = {"metadata": {}}
+    extra = {"request_id": "req-1", "account": "acct", "org_id": "org"}
+
+    h.handle(msg, "test", extra, send_message=send)
+
+    topics = [call.args[0] for call in send.call_args_list]
+    assert topics[0] == "tracker"
+    assert "inventory" in topics
+    assert topics[-1] == "tracker"
+    mock_metrics.msg_processed_success.labels.assert_called_with("test")
+
+
+@patch("src.puptoo.handlers.base.upload_object")
+@patch("src.puptoo.handlers.base.msgs")
+@patch("src.puptoo.handlers.base.validators")
+@patch("src.puptoo.handlers.base.config")
+@patch("src.puptoo.handlers.base.metrics")
+def test_handle_error_path(
+    mock_metrics, mock_config, mock_validators, mock_msgs, mock_upload
+):
+    mock_validators.validateCanonicalFacts.return_value = False
+    mock_config.TRACKER_TOPIC = "tracker"
+    mock_config.VALIDATION_TOPIC = "validation"
+
+    send = MagicMock()
+    h = DummyHandler()
+    msg = {"metadata": {}}
+    extra = {"request_id": "req-1", "account": "acct", "org_id": "org"}
+
+    h.handle(msg, "test", extra, send_message=send)
+
+    topics = [call.args[0] for call in send.call_args_list]
+    assert "tracker" in topics
+    assert "validation" in topics
+    mock_metrics.msg_processed_failure.labels.assert_called_with("test")
+
+
+@patch("src.puptoo.handlers.base.upload_object")
+@patch("src.puptoo.handlers.base.msgs")
+@patch("src.puptoo.handlers.base.validators")
+@patch("src.puptoo.handlers.base.config")
+@patch("src.puptoo.handlers.base.metrics")
+def test_handle_empty_facts_triggers_error_path(
+    mock_metrics, mock_config, mock_validators, mock_msgs, mock_upload
+):
+    mock_config.TRACKER_TOPIC = "tracker"
+    mock_config.VALIDATION_TOPIC = "validation"
+
+    class EmptyHandler(BaseHandler):
+        def process(self, msg: dict, extra: dict) -> dict:
+            return {}
+
+        def build_hbi_messages(self, facts: dict, msg: dict) -> list[dict]:
+            return []
+
+    send = MagicMock()
+    h = EmptyHandler()
+    msg = {"metadata": {}}
+    extra = {"request_id": "req-1", "account": "acct", "org_id": "org"}
+
+    h.handle(msg, "test", extra, send_message=send)
+
+    mock_metrics.msg_processed_failure.labels.assert_called_with("test")


### PR DESCRIPTION
refactor: replace inline service routing with handler registry pattern

Introduce concrete handlers (AdvisorHandler, ComplianceHandler,
MalwareDetectionHandler) registered via @handler decorator, and move
shared post-processing logic from handle_message() into a BaseHandler
template method. This simplifies app.py by removing process_archive()
and handle_message() in favor of get_handler() dispatch.

Acceptance Criteria Coverage:
- test_dispatch_advisor: advisor -> AdvisorHandler
- test_dispatch_compliance: compliance -> ComplianceHandler
- test_dispatch_malware_detection: malware-detection -> MalwareDetectionHandler
- test_dispatch_qpc_returns_none: qpc -> None
- test_dispatch_unknown_returns_none: unknown -> None

Fixes: RHINENG-27904, RHINENG-27905, RHINENG-27906,
        RHINENG-27907, RHINENG-27913

Co-Authored-By: Pranav Lawate <plawate@redhat.com>

## Summary by Sourcery

Introduce a handler registry and shared BaseHandler template to route and process messages per service instead of inline logic in app.py.

Enhancements:
- Refactor message processing to use dedicated Advisor, Compliance, and MalwareDetection handlers registered via a handler registry.
- Extract shared fact enrichment, validation, and messaging workflow into a reusable BaseHandler.handle template method.
- Move utility functions for stale time calculation, owner extraction, and MAC cleaning into the handler base module and update imports accordingly.

Tests:
- Add comprehensive tests for the handler registry, BaseHandler template behavior, and concrete handlers, and update existing tests to target the new helper locations.