### PR TITLE
refactor(RHINENG-27908): extract shared Kafka auth config into mq/auth.py

### DIFF
--- a/src/puptoo/app.py
+++ b/src/puptoo/app.py
@@ -9,6 +9,7 @@ from prometheus_client import Info, Summary, start_http_server
 
 from .handlers import get_handler
 from .mq import consume, produce
+from .mq.auth import write_kafka_cert
 from .utils import config, metrics, puptoo_logging
 from .utils.puptoo_logging import threadctx
 from redis import Redis
@@ -21,11 +22,6 @@ CONSUMER_ASSIGNMENTS = Info(
 )
 
 logger = puptoo_logging.initialize_logging()
-
-
-def write_cert(cert):
-    with open("/tmp/cacert", "w") as f:
-        f.write(cert)
 
 
 def start_prometheus():
@@ -82,9 +78,7 @@ def main():
 
         config.log_config()
 
-        if config.KAFKA_BROKER:
-            if config.KAFKA_BROKER.cacert:
-                write_cert(config.KAFKA_BROKER.cacert)
+        write_kafka_cert()
 
         consumer = consume.init_consumer()
         global producer

--- a/src/puptoo/mq/auth.py
+++ b/src/puptoo/mq/auth.py
@@ -1,0 +1,28 @@
+import os
+
+from ..utils import config
+
+CACERT_PATH = "/tmp/cacert"
+
+
+def write_kafka_cert():
+    if config.KAFKA_BROKER and config.KAFKA_BROKER.cacert:
+        fd = os.open(CACERT_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(config.KAFKA_BROKER.cacert)
+
+
+def kafka_auth_config(connection_info):
+    if config.KAFKA_BROKER:
+        if config.KAFKA_BROKER.cacert:
+            connection_info["ssl.ca.location"] = CACERT_PATH
+        if config.KAFKA_BROKER.sasl and config.KAFKA_BROKER.sasl.username:
+            connection_info.update(
+                {
+                    "security.protocol": config.KAFKA_BROKER.sasl.securityProtocol,
+                    "sasl.mechanisms": config.KAFKA_BROKER.sasl.saslMechanism,
+                    "sasl.username": config.KAFKA_BROKER.sasl.username,
+                    "sasl.password": config.KAFKA_BROKER.sasl.password,
+                }
+            )
+    return connection_info

--- a/src/puptoo/mq/consume.py
+++ b/src/puptoo/mq/consume.py
@@ -1,6 +1,7 @@
 from confluent_kafka import Consumer
 
 from ..utils import config
+from .auth import kafka_auth_config
 
 
 def init_consumer():
@@ -13,18 +14,7 @@ def init_consumer():
         "bootstrap.servers": ",".join(config.BOOTSTRAP_SERVERS),
     }
 
-    if config.KAFKA_BROKER:
-        if config.KAFKA_BROKER.cacert:
-            connection_info["ssl.ca.location"] = "/tmp/cacert"
-        if config.KAFKA_BROKER.sasl and config.KAFKA_BROKER.sasl.username:
-            connection_info.update(
-                {
-                    "security.protocol": config.KAFKA_BROKER.sasl.securityProtocol,
-                    "sasl.mechanisms": config.KAFKA_BROKER.sasl.saslMechanism,
-                    "sasl.username": config.KAFKA_BROKER.sasl.username,
-                    "sasl.password": config.KAFKA_BROKER.sasl.password,
-                }
-            )
+    kafka_auth_config(connection_info)
 
     consumer = Consumer(connection_info)
 

--- a/src/puptoo/mq/produce.py
+++ b/src/puptoo/mq/produce.py
@@ -1,24 +1,16 @@
 from confluent_kafka import Producer
 
 from ..utils import config
+from .auth import kafka_auth_config
 
 
 def init_producer():
 
-    connection_info = {"bootstrap.servers": ",".join(config.BOOTSTRAP_SERVERS)}
+    connection_info = {
+        "bootstrap.servers": ",".join(config.BOOTSTRAP_SERVERS),
+    }
 
-    if config.KAFKA_BROKER:
-        if config.KAFKA_BROKER.cacert:
-            connection_info["ssl.ca.location"] = "/tmp/cacert"
-        if config.KAFKA_BROKER.sasl and config.KAFKA_BROKER.sasl.username:
-            connection_info.update(
-                {
-                    "security.protocol": config.KAFKA_BROKER.sasl.securityProtocol,
-                    "sasl.mechanisms": config.KAFKA_BROKER.sasl.saslMechanism,
-                    "sasl.username": config.KAFKA_BROKER.sasl.username,
-                    "sasl.password": config.KAFKA_BROKER.sasl.password,
-                }
-            )
+    kafka_auth_config(connection_info)
 
     producer = Producer(connection_info)
     return producer

--- a/tests/test_mq_auth.py
+++ b/tests/test_mq_auth.py
@@ -1,0 +1,104 @@
+import os
+from unittest.mock import MagicMock, mock_open, patch
+
+from src.puptoo.mq.auth import CACERT_PATH, kafka_auth_config, write_kafka_cert
+
+
+@patch("src.puptoo.mq.auth.config")
+def test_kafka_auth_config_with_sasl(mock_config):
+    mock_config.KAFKA_BROKER = MagicMock()
+    mock_config.KAFKA_BROKER.cacert = "some-cert"
+    mock_config.KAFKA_BROKER.sasl.username = "user"
+    mock_config.KAFKA_BROKER.sasl.password = "pass"
+    mock_config.KAFKA_BROKER.sasl.securityProtocol = "SASL_SSL"
+    mock_config.KAFKA_BROKER.sasl.saslMechanism = "SCRAM-SHA-512"
+
+    info = {"bootstrap.servers": "localhost:9092"}
+    result = kafka_auth_config(info)
+
+    assert result is info
+    assert result["ssl.ca.location"] == CACERT_PATH
+    assert result["security.protocol"] == "SASL_SSL"
+    assert result["sasl.mechanisms"] == "SCRAM-SHA-512"
+    assert result["sasl.username"] == "user"
+    assert result["sasl.password"] == "pass"
+
+
+@patch("src.puptoo.mq.auth.config")
+def test_kafka_auth_config_without_broker(mock_config):
+    mock_config.KAFKA_BROKER = None
+
+    info = {"bootstrap.servers": "localhost:9092"}
+    result = kafka_auth_config(info)
+
+    assert result == {"bootstrap.servers": "localhost:9092"}
+
+
+@patch("src.puptoo.mq.auth.config")
+def test_kafka_auth_config_cacert_only(mock_config):
+    mock_config.KAFKA_BROKER = MagicMock()
+    mock_config.KAFKA_BROKER.cacert = "some-cert"
+    mock_config.KAFKA_BROKER.sasl = None
+
+    info = {"bootstrap.servers": "localhost:9092"}
+    result = kafka_auth_config(info)
+
+    assert result["ssl.ca.location"] == CACERT_PATH
+    assert "security.protocol" not in result
+    assert "sasl.mechanisms" not in result
+
+
+@patch("src.puptoo.mq.auth.config")
+def test_kafka_auth_config_no_cacert_no_sasl(mock_config):
+    mock_config.KAFKA_BROKER = MagicMock()
+    mock_config.KAFKA_BROKER.cacert = None
+    mock_config.KAFKA_BROKER.sasl = None
+
+    info = {"bootstrap.servers": "localhost:9092"}
+    result = kafka_auth_config(info)
+
+    assert "ssl.ca.location" not in result
+    assert "security.protocol" not in result
+
+
+@patch("src.puptoo.mq.auth.config")
+def test_write_kafka_cert_writes_file_with_restricted_permissions(mock_config):
+    mock_config.KAFKA_BROKER = MagicMock()
+    mock_config.KAFKA_BROKER.cacert = (
+        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
+    )
+
+    m = mock_open()
+    fake_fd = 42
+    with (
+        patch("src.puptoo.mq.auth.os.open", return_value=fake_fd) as mock_os_open,
+        patch("src.puptoo.mq.auth.os.fdopen", m),
+    ):
+        write_kafka_cert()
+
+    mock_os_open.assert_called_once_with(
+        CACERT_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+    )
+    m.assert_called_once_with(fake_fd, "w")
+    m().__enter__().write.assert_called_once_with(mock_config.KAFKA_BROKER.cacert)
+
+
+@patch("src.puptoo.mq.auth.config")
+def test_write_kafka_cert_noop_without_broker(mock_config):
+    mock_config.KAFKA_BROKER = None
+
+    with patch("src.puptoo.mq.auth.os.open") as mock_os_open:
+        write_kafka_cert()
+
+    mock_os_open.assert_not_called()
+
+
+@patch("src.puptoo.mq.auth.config")
+def test_write_kafka_cert_noop_without_cacert(mock_config):
+    mock_config.KAFKA_BROKER = MagicMock()
+    mock_config.KAFKA_BROKER.cacert = None
+
+    with patch("src.puptoo.mq.auth.os.open") as mock_os_open:
+        write_kafka_cert()
+
+    mock_os_open.assert_not_called()


### PR DESCRIPTION
Create a kafka_auth_config() function adopting yuptoo's pattern to eliminate the identical SASL/SSL configuration block duplicated across consume.py and produce.py. Move write_cert() from app.py into the same module with a CACERT_PATH constant replacing the hardcoded path.

No change to Kafka auth behaviour — same SASL and cacert handling, just consolidated into a single source of truth.

Co-Authored-By: Pranav Lawate <plawate@redhat.com>

## Summary by Sourcery

Extract shared Kafka authentication configuration into a dedicated mq.auth module and update consumers and producers to use it.

Enhancements:
- Introduce a reusable kafka_auth_config helper and CACERT_PATH constant to centralize Kafka SASL/SSL settings and cert handling.
- Refactor consumer and producer initialization to delegate Kafka auth setup to the shared helper while keeping behavior unchanged.

Tests:
- Add unit tests covering kafka_auth_config behavior across broker/cert/SASL combinations and write_cert side effects.