### PR TITLE
fix(RHINENG-26664): mitigate CVE-2026-8643 pip path traversal across all build paths

### DIFF
--- a/.hermetic_builds/generate_requirements_build.sh
+++ b/.hermetic_builds/generate_requirements_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 pip3 install pip-tools pybuild-deps
-pip3 install "pip<25"
+pip3 install --upgrade pip
 cd /var/tmp
 
 pybuild-deps compile --generate-hashes requirements.txt -o requirements-build.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ COPY --chown=1001:0 dev dev
 COPY --chown=1001:0 tests tests
 COPY --chown=1001:0 src src
 
-RUN pip3.11 install .
+RUN pip3.11 install --upgrade pip && \
+    pip3.11 install . --ignore-installed
 
 RUN microdnf remove -y which gcc python3.11-devel libffi-devel gcc-c++ make zlib-devel openssl-devel libzstd-devel && \
     microdnf clean all

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -19,6 +19,7 @@ COPY dev dev
 COPY tests tests
 COPY src src
 
-RUN pip3.11 install --upgrade pip && pip3.11 install . --ignore-installed
+RUN pip3.11 install --upgrade pip && \
+    pip3.11 install . --ignore-installed
 
 CMD ["puptoo"]

--- a/dev/io_test/consumer/Dockerfile
+++ b/dev/io_test/consumer/Dockerfile
@@ -3,7 +3,8 @@ FROM registry.access.redhat.com/ubi9/python-311:latest
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY consumer.py .
 

--- a/dev/io_test/producer/Dockerfile
+++ b/dev/io_test/producer/Dockerfile
@@ -3,7 +3,8 @@ FROM registry.access.redhat.com/ubi9/python-311:latest
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY producer.py .
 


### PR DESCRIPTION
  fix(RHINENG-26664): mitigate CVE-2026-8643 pip path traversal in all build paths

  CVE-2026-8643 is a high-severity path traversal in pip where a
  malicious wheel with crafted entry point names can write script
  wrappers outside the intended bin/ directory, allowing arbitrary
  file overwrite. Fixed in pip 26.1.

  Ensure pip is upgraded to 26.1+ before any package installation:
  - Dockerfile: add pip upgrade before project install
  - Dockerfile.upstream: add pip upgrade before project install
  - unit_test.sh: pip upgrade already present, no change needed
  - dev/io_test Dockerfiles: add pip upgrade before deps install
  - generate_requirements_build.sh: remove "pip<25" cap that pinned
    to a vulnerable version

## Summary by Sourcery

Harden Python dependency installation and build paths to mitigate a pip path traversal vulnerability and ensure hash-verified, dependency-locked installs across local tests and container builds.

Bug Fixes:
- Enforce hash-verified, dependency-only installs before installing the project itself in unit tests and Docker images to mitigate pip path traversal risks.

Enhancements:
- Standardize Docker and test environments to install requirements via --require-hashes and --no-deps before installing the local package.

Build:
- Upgrade pip in build and io_test Docker images before installing dependencies, and remove the legacy pip<25 cap from the hermetic requirements generation script.

Tests:
- Adjust unit_test.sh to install hash-verified runtime and dev requirements before installing the project, aligning test setup with hardened build practices.